### PR TITLE
1.2.0

### DIFF
--- a/admin/cpt-admin.js
+++ b/admin/cpt-admin.js
@@ -9,7 +9,7 @@
         break;
 
       case 'Cancel':
-      default :
+      default:
         $( this ).html( 'Edit Client' );
         break;
 

--- a/admin/cpt-edit-client.php
+++ b/admin/cpt-edit-client.php
@@ -179,7 +179,7 @@ function cpt_delete_client_modal( $user_id ) {
           <h2 style="color: red;"><?php _e( 'WARNING' ); ?></h2>
 
           <p><?php _e( '<strong>Deleting a client is permanent.</strong> There is no undo. Make sure you have a backup!' ); ?></p>
-          <p><?php _e( 'Deleting a client will also remove messages and other client information.' ); ?></p>
+          <p><?php _e( 'Deleting a client will also remove the associated user account, client messages, and other client information.' ); ?></p>
 
           <?php cpt_delete_client_button( $user_id ); ?>
           <button class="button cpt-cancel-delete-client"><?php _e( 'Cancel' ); ?></button>

--- a/admin/cpt-settings.php
+++ b/admin/cpt-settings.php
@@ -188,23 +188,23 @@ function cpt_default_client_status() {
 }
 
 
-// Client Messaging Settings
-function cpt_client_messaging_settings_init() {
+// Status Update Request Button settings
+function cpt_status_update_request_button_settings_init() {
 
   add_settings_section(
-    'cpt_client_messaging_settings',
-    'Messages',
-    __NAMESPACE__ . '\cpt_client_messaging_section',
+    'cpt_status_update_request_button_settings',
+    'Status Update Request Button',
+    __NAMESPACE__ . '\cpt_status_update_request_button_section',
     'cpt-settings',
   );
 
   // Show Status Update Request Button
   add_settings_field(
     'cpt_show_status_update_req_button',
-    '<label for="cpt_show_status_update_req_button">Show Status Update Request Button?</label>',
+    'Show/Hide',
     __NAMESPACE__ . '\cpt_show_status_update_req_button',
     'cpt-settings',
-    'cpt_client_messaging_settings',
+    'cpt_status_update_request_button_settings',
   );
 
   register_setting( 'cpt-settings', 'cpt_show_status_update_req_button', 'absint' );
@@ -215,7 +215,7 @@ function cpt_client_messaging_settings_init() {
     '<label for="cpt_status_update_req_freq">Status Update Request Frequency<br /><small>(required)</small></label>',
     __NAMESPACE__ . '\cpt_status_update_req_freq',
     'cpt-settings',
-    'cpt_client_messaging_settings',
+    'cpt_status_update_request_button_settings',
   );
 
   register_setting( 'cpt-settings', 'cpt_status_update_req_freq', 'absint' );
@@ -226,25 +226,37 @@ function cpt_client_messaging_settings_init() {
     '<label for="cpt_status_update_req_notice_email">Status Update Request Notification Email<br /><small>(required)</small></label>',
     __NAMESPACE__ . '\cpt_status_update_req_notice_email',
     'cpt-settings',
-    'cpt_client_messaging_settings',
+    'cpt_status_update_request_button_settings',
   );
 
   register_setting( 'cpt-settings', 'cpt_status_update_req_notice_email', 'sanitize_email' );
 
 }
 
-add_action( 'admin_init', __NAMESPACE__ . '\cpt_client_messaging_settings_init' );
+add_action( 'admin_init', __NAMESPACE__ . '\cpt_status_update_request_button_settings_init' );
 
-function cpt_client_messaging_section() {}
+
+function cpt_status_update_request_button_section() {}
 
 function cpt_show_status_update_req_button() {
 
-  $show_button  = get_option( 'cpt_show_status_update_req_button', 'empty' );
+  $show_button = get_option( 'cpt_show_status_update_req_button', true );
 
-  if ( $show_button == 'empty' ) { $show_button = '1'; }
+  ob_start();
 
-  echo '<input name="cpt_show_status_update_req_button" type="checkbox" value="1"' . checked( 1, $show_button, false ) . '>';
-  echo '<p class="description">' . __( 'Uncheck this box to hide the Status Update Request Button on the client dashboard.' ) . '</p>';
+    ?>
+
+      <fieldset>
+        <label for="cpt_show_status_update_req_button">
+          <input name="cpt_show_status_update_req_button" id="cpt_show_status_update_req_button" type="checkbox" value="1" <?php checked( $show_button ); ?>>
+          Show button?
+          <p class="description"><?php _e( 'Uncheck this box to hide the Status Update Request Button on the client dashboard.' ); ?></p>
+        </label>
+      </fieldset>
+
+    <?php
+
+  echo ob_get_clean();
 
 }
 
@@ -256,6 +268,57 @@ function cpt_status_update_req_freq() {
 function cpt_status_update_req_notice_email() {
   echo '<input name="cpt_status_update_req_notice_email" class="regular-text" type="email" required aria-required="true" value="' . get_option( 'cpt_status_update_req_notice_email' ) . '">';
   echo '<p class="description">' . __( 'When a client requests a status update, the notification will go to this email address.' ) . '</p>';
+}
+
+
+// Client Messaging Settings
+function cpt_client_messaging_settings_init() {
+
+  add_settings_section(
+    'cpt_client_messaging_settings',
+    'Messages',
+    __NAMESPACE__ . '\cpt_client_messaging_section',
+    'cpt-settings',
+  );
+
+  // Send Message Content
+  add_settings_field(
+    'cpt_send_message_content',
+    'Email Notification Content',
+    __NAMESPACE__ . '\cpt_send_message_content',
+    'cpt-settings',
+    'cpt_client_messaging_settings',
+  );
+
+  register_setting( 'cpt-settings', 'cpt_send_message_content', 'absint' );
+
+}
+
+add_action( 'admin_init', __NAMESPACE__ . '\cpt_client_messaging_settings_init' );
+
+
+function cpt_client_messaging_section() {}
+
+function cpt_send_message_content() {
+
+  $send_message_content = get_option( 'cpt_send_message_content' );
+
+  ob_start();
+
+    ?>
+
+      <fieldset>
+        <label for="cpt_send_message_content">
+          <input name="cpt_send_message_content" id="cpt_send_message_content" type="checkbox" value="1" <?php checked( $send_message_content ); ?>>
+          Send message content
+          <p class="description"><?php _e( 'If checked, the client will receive the full content of messages by email instead of a notification with a prompt to log into their client portal. This is less secure.' ); ?></p>
+        </label>
+      </fieldset>
+
+    <?php
+
+  echo ob_get_clean();
+
 }
 
 

--- a/admin/cpt-settings.php
+++ b/admin/cpt-settings.php
@@ -198,6 +198,17 @@ function cpt_client_messaging_settings_init() {
     'cpt-settings',
   );
 
+  // Show Status Update Request Button
+  add_settings_field(
+    'cpt_show_status_update_req_button',
+    '<label for="cpt_show_status_update_req_button">Show Status Update Request Button?</label>',
+    __NAMESPACE__ . '\cpt_show_status_update_req_button',
+    'cpt-settings',
+    'cpt_client_messaging_settings',
+  );
+
+  register_setting( 'cpt-settings', 'cpt_show_status_update_req_button', 'absint' );
+
   // Status Update Request Frequency
   add_settings_field(
     'cpt_status_update_req_freq',
@@ -225,6 +236,17 @@ function cpt_client_messaging_settings_init() {
 add_action( 'admin_init', __NAMESPACE__ . '\cpt_client_messaging_settings_init' );
 
 function cpt_client_messaging_section() {}
+
+function cpt_show_status_update_req_button() {
+
+  $show_button  = get_option( 'cpt_show_status_update_req_button', 'empty' );
+
+  if ( $show_button == 'empty' ) { $show_button = '1'; }
+
+  echo '<input name="cpt_show_status_update_req_button" type="checkbox" value="1"' . checked( 1, $show_button, false ) . '>';
+  echo '<p class="description">' . __( 'Uncheck this box to hide the Status Update Request Button on the client dashboard.' ) . '</p>';
+
+}
 
 function cpt_status_update_req_freq() {
   echo '<input name="cpt_status_update_req_freq" class="small-text" type="number" required aria-required="true" value="' . get_option( 'cpt_status_update_req_freq' ) . '"> days';

--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,8 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 
 #### Added
 - Setting to disable the status request button entirely.
+- Setting to change the default email behavior to include the full message, rather than just a notification.
+- Override the default email behavior on individual messages.
 
 #### Changed
 - Creating a new client with an existing user's email address now adds the Client role to the existing user instead of returning an error.

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,9 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 ### Added
 - Setting to disable the status request button entirely.
 
+### Changed
+- Creating a new client with an existing user's email address now adds the Client role to the existing user instead of returning an error.
+
 
 ## [1.1.0] - 2020-10-20
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file. The format
 is based on [Keep a Changelog](https://keepachangelog.com).
 
 
-## [1.2.0]
+### [1.2.0]
 
 #### Added
 - Setting to disable the status request button entirely.
@@ -13,13 +13,13 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - Creating a new client with an existing user's email address now adds the Client role to the existing user instead of returning an error.
 
 
-## [1.1.0] - 2020-10-20
+### [1.1.0] - 2020-10-20
 
 #### Added
 - Delete a client from the client's profile page, under **Edit Client**.
 
 
-## [1.0.5] - 2020-10-07
+### [1.0.5] - 2020-10-07
 
 #### Changed
 - Handle frontend login error on the front end.
@@ -33,13 +33,13 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - Email notifications should now deliver with the intended formatting.
 
 
-## [1.0.4] - 2020-10-05
+### [1.0.4] - 2020-10-05
 
 #### Fixed
 - Prevent not-logged-in messages from displaying in the head when the_content filter is called (by Yoast SEO, for example).
 
 
-## [1.0.3] - 2020-10-05
+### [1.0.3] - 2020-10-05
 
 #### Fixed
 - Center the modal dismiss button.
@@ -47,20 +47,20 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - Prevent Client Power Tools from intercepting the password reset workflow for non-clients.
 
 
-## [1.0.2] - 2020-10-02
+### [1.0.2] - 2020-10-02
 
 #### Fixed
 - Fixed URL encoding.
 
 
-## [1.0.1] - 2020-10-02
+### [1.0.1] - 2020-10-02
 
 #### Fixed
 - Check for main query on client dashboard.
 - Fixed set/change password key sanitization.
 
 
-## [1.0.0] - 2020-10-02
+### [1.0.0] - 2020-10-02
 
 #### Added
 - Added some frontend form styles for greater compatibility with different themes.
@@ -71,7 +71,7 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - Data sanitization and validation.
 
 
-## [0.1.0 (Beta)] - 2020-09-23
+### [0.1.0 (Beta)] - 2020-09-23
 
 #### Added
 - Everything.

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,7 +3,11 @@
 All notable changes to this project will be documented in this file. The format
 is based on [Keep a Changelog](https://keepachangelog.com).
 
-## [Unreleased]
+
+## [1.2.0]
+
+### Added
+- Setting to disable the status request button entirely.
 
 
 ## [1.1.0] - 2020-10-20

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,42 +6,42 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 
 ## [1.2.0]
 
-### Added
+#### Added
 - Setting to disable the status request button entirely.
 
-### Changed
+#### Changed
 - Creating a new client with an existing user's email address now adds the Client role to the existing user instead of returning an error.
 
 
 ## [1.1.0] - 2020-10-20
 
-### Added
+#### Added
 - Delete a client from the client's profile page, under **Edit Client**.
 
 
 ## [1.0.5] - 2020-10-07
 
-### Changed
+#### Changed
 - Handle frontend login error on the front end.
 - General tidying up.
 
-### Removed
+#### Removed
 - Remove unused capabilities from Client Manager role (for now).
 - Remove unused functions cpt_get_client_profile_link and cpt_get_client_id.
 
-### Fixed
+#### Fixed
 - Email notifications should now deliver with the intended formatting.
 
 
 ## [1.0.4] - 2020-10-05
 
-### Fixed
+#### Fixed
 - Prevent not-logged-in messages from displaying in the head when the_content filter is called (by Yoast SEO, for example).
 
 
 ## [1.0.3] - 2020-10-05
 
-### Fixed
+#### Fixed
 - Center the modal dismiss button.
 - Fix false negatives from cpt_is_client if the user is not logged in but the user ID is provided.
 - Prevent Client Power Tools from intercepting the password reset workflow for non-clients.
@@ -49,23 +49,23 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 
 ## [1.0.2] - 2020-10-02
 
-### Fixed
+#### Fixed
 - Fixed URL encoding.
 
 
 ## [1.0.1] - 2020-10-02
 
-### Fixed
+#### Fixed
 - Check for main query on client dashboard.
 - Fixed set/change password key sanitization.
 
 
 ## [1.0.0] - 2020-10-02
 
-### Added
+#### Added
 - Added some frontend form styles for greater compatibility with different themes.
 
-### Changed
+#### Changed
 - Override default button display style on dismiss button.
 - Change constant prefix from CPT_ to CLIENT_POWER_TOOLS_.
 - Data sanitization and validation.
@@ -73,5 +73,5 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 
 ## [0.1.0 (Beta)] - 2020-09-23
 
-### Added
+#### Added
 - Everything.

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. The format
 is based on [Keep a Changelog](https://keepachangelog.com).
 
 
+### Unreleased
+- Prepare the plugin for internationalization.
+
+
 ### [1.2.0]
 
 #### Added

--- a/client-power-tools.php
+++ b/client-power-tools.php
@@ -144,6 +144,7 @@ function cpt_activate() {
 		'cpt_show_status_update_req_button'		=> true,
 		'cpt_status_update_req_freq'					=> 30,
 		'cpt_status_update_req_notice_email'	=> get_bloginfo( 'admin_email' ),
+		'cpt_send_message_content'						=> false,
     'cpt_new_client_email_from_name'     	=> '',
     'cpt_new_client_email_from_email'    	=> get_bloginfo( 'admin_email' ),
     'cpt_new_client_email_subject_line'  	=> 'Your client account has been created! Please set your password.',

--- a/client-power-tools.php
+++ b/client-power-tools.php
@@ -141,6 +141,7 @@ function cpt_activate() {
 	$defaults = [
 		'cpt_client_statuses'									=> 'Active' . "\n" . 'Potential' . "\n" . 'Inactive',
 		'cpt_default_client_status'						=> 'Active',
+		'cpt_show_status_update_req_button'		=> true,
 		'cpt_status_update_req_freq'					=> 30,
 		'cpt_status_update_req_notice_email'	=> get_bloginfo( 'admin_email' ),
     'cpt_new_client_email_from_name'     	=> '',

--- a/client-power-tools.php
+++ b/client-power-tools.php
@@ -5,7 +5,7 @@ Plugin Name: Client Power Tools
 Plugin URI: https://clientpowertools.com
 Description: Client Power Tools is an easy-to-use private client dashboard and communication portal built for independent contractors, consultants, lawyers, and other professionals.
 Author: Sam Glover
-Version: 1.1.0
+Version: 1.2.0
 Author URI: https://samglover.net
 */
 
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 /**
 * Constants
 */
-define( 'CLIENT_POWER_TOOLS_PLUGIN_VERSION', '1.1.0' );
+define( 'CLIENT_POWER_TOOLS_PLUGIN_VERSION', '1.2.0' );
 define( 'CLIENT_POWER_TOOLS_DIR_PATH', plugin_dir_path( __FILE__ ) );
 define( 'CLIENT_POWER_TOOLS_DIR_URL', plugin_dir_url( __FILE__ ) );
 

--- a/common/cpt-client-dashboard.php
+++ b/common/cpt-client-dashboard.php
@@ -26,9 +26,6 @@ function cpt_client_dashboard( $content ) {
       $user         = get_userdata( $user_id );
       $client_data  = cpt_get_client_data( $user_id );
 
-      $request_frequency       = get_option( 'cpt_status_update_req_freq' );
-      $days_since_last_request = cpt_days_since_last_request( $user_id );
-
       if ( cpt_is_client() ) {
 
         ob_start();
@@ -36,10 +33,7 @@ function cpt_client_dashboard( $content ) {
           echo '<p>Welcome back, ' . $client_data[ 'first_name' ] . '!</p>';
 
           cpt_get_notices( 'cpt_new_message_result' );
-
-          if ( is_null( $days_since_last_request ) || $days_since_last_request > $request_frequency ) {
-            cpt_status_update_request_button( $user_id );
-          }
+          cpt_status_update_request_button( $user_id );
 
           /**
           * Removes the the_content filter so it doesn't execute within the
@@ -76,6 +70,21 @@ add_filter( 'the_content', __NAMESPACE__ . '\cpt_client_dashboard' );
 
 
 function cpt_status_update_request_button( $user_id ) {
+
+  if ( ! $user_id ) { return; }
+
+  // Return if the option to show the Status Update Request button is unchecked.
+  $show_button = get_option( 'cpt_show_status_update_req_button', 'empty' );
+
+  if ( $show_button == 'empty' ) { $value = '1'; }
+  if ( ! $show_button ) { return; }
+
+  // Return if the client clicked the button more recently than the request
+  // frequency option allows.
+  $request_frequency       = get_option( 'cpt_status_update_req_freq' );
+  $days_since_last_request = cpt_days_since_last_request( $user_id );
+
+  if ( ! is_null( $days_since_last_request ) && $days_since_last_request < $request_frequency ) { return; }
 
   ob_start();
 

--- a/common/cpt-messages.php
+++ b/common/cpt-messages.php
@@ -154,10 +154,36 @@ function cpt_new_message_form( $user_id ) {
                   <?php \wp_editor( '', 'cpt-message-editor', $editor_args ); ?>
                 </td>
               </tr>
+              <tr>
+                <th scope="row">
+                  Options
+                </th>
+                <td>
+                  <fieldset>
+
+                    <?php if ( get_option( 'cpt_send_message_content' ) == false ) { ?>
+
+                      <label for="send_message_content">
+                        <input name="send_message_content" id="send_message_content" type="checkbox" value="1">
+                        <?php _e( 'Send message content.' ); ?>
+                      </label>
+                      <p class="description"><?php _e( 'If checked, the client will receive the actual message by email instead of a notification with a prompt to log into their client portal. This is less secure.' ); ?></p>
+
+                    <?php } else { ?>
+
+                      <label for="send_notification_only">
+                        <input name="send_notification_only" id="send_notification_only" type="checkbox" value="1">
+                        <?php _e( 'Send notification only.' ); ?>
+                      </label>
+                      <p class="description"><?php _e( 'If checked, the client will receive an email letting them know they have a message, but they will have to log into their client dashboard to view the body of the message. This is more secure.' ); ?></p>
+
+                    <?php } ?>
+
+                  </fieldset>
+                </td>
+              </tr>
             </tbody>
           </table>
-
-          <p><?php _e( 'When you click send, this client will receive an email letting them know they have a message, but they will have to log into their client dashboard to view the body of the message.' ); ?></p>
 
           <p class="submit">
             <input name="submit" id="submit" class="button button-primary" type="submit" value="<?php _e( 'Send Message' ); ?>">
@@ -244,6 +270,34 @@ function cpt_process_new_message() {
     $post_content     = wp_kses_post( $_POST[ 'message' ] );
     $clients_user_id  = sanitize_key( intval( $_POST[ 'clients_user_id' ] ) );
 
+    // Figures out whether to send the full content of this message.
+    $send_msg_content_default = get_option( 'cpt_send_message_content' );
+
+    switch ( $send_msg_content_default ) {
+
+      case ( $send_msg_content_default == true ):
+
+        if ( isset( $_POST[ 'send_notification_only' ] ) && $_POST[ 'send_notification_only' ] == 1 ) {
+          $send_this_msg_content = false;
+        } else {
+          $send_this_msg_content = true;
+        }
+
+        break;
+
+      case ( $send_msg_content_default == false ):
+      default:
+
+        if ( isset( $_POST[ 'send_message_content' ] ) && $_POST[ 'send_message_content' ] == 1 ) {
+          $send_this_msg_content = true;
+        } else {
+          $send_this_msg_content = false;
+        }
+
+        break;
+
+    }
+
     /**
     * Note. When creating a new message, for the post slug we generate an md5
     * hash from the timestamp plus a random integer, making the message URL
@@ -256,7 +310,8 @@ function cpt_process_new_message() {
       'post_status'   => 'publish',
       'post_type'     => 'cpt_message',
       'meta_input'    => [
-        'cpt_clients_user_id' => $clients_user_id,
+        'cpt_clients_user_id'       => $clients_user_id,
+        'cpt_send_message_content'  => $send_this_msg_content,
       ],
     ];
 
@@ -287,12 +342,14 @@ function cpt_process_new_message() {
 
 }
 
-add_action( 'admin_post_cpt_new_message_added', __NAMESPACE__ . '\cpt_process_new_message' );
+// add_action( 'admin_post_cpt_new_message_added', __NAMESPACE__ . '\cpt_process_new_message' );
 
 
 function cpt_message_notification( $message_id ) {
 
   if ( ! $message_id ) { return; }
+
+  $send_this_msg_content = get_post_meta( $message_id, 'cpt_send_message_content', true );
 
   $msg_obj          = get_post( $message_id );
   $sender_id        = $msg_obj->post_author;
@@ -308,21 +365,28 @@ function cpt_message_notification( $message_id ) {
   $to               = $client_obj->user_email;
   $subject          = $msg_obj->post_title ? $msg_obj->post_title : __( 'You have a new message from' ) . ' ' . $from_name;
 
-  if ( $sender_id == $clients_user_id ) {
+  if ( $send_this_msg_content ) {
 
-    $message      = '<p>' . __( 'To read your message, please visit your client dashboard.' ) . '</p>';
-    $button_url   = cpt_get_client_profile_url( $clients_user_id ) . '#cpt-message-' . $message_id;
+    $message = get_the_content( null, false, $msg_obj );
 
   } else {
 
-    $message      = '<p>' . __( 'To read this message, please view the client page.' ) . '</p>';
-    $button_url   = cpt_get_client_dashboard_url() . '#cpt-message-' . $message_id;
+    if ( $sender_id == $clients_user_id ) {
+
+      $message      = '<p>' . __( 'To read your message, please visit your client dashboard.' ) . '</p>';
+      $button_url   = cpt_get_client_profile_url( $clients_user_id ) . '#cpt-message-' . $message_id;
+
+    } else {
+
+      $message      = '<p>' . __( 'To read this message, please view the client page.' ) . '</p>';
+      $button_url   = cpt_get_client_dashboard_url() . '#cpt-message-' . $message_id;
+
+    }
+
+    $button_txt     = __( 'Go to Message' );
+    $message        = cpt_get_email_card( $subject, $message, $button_txt, $button_url );
 
   }
-
-  $button_txt     = __( 'Go to Message' );
-
-  $message = cpt_get_email_card( $subject, $message, $button_txt, $button_url );
 
   wp_mail( $to, $subject, $message, $headers );
 

--- a/common/cpt-messages.php
+++ b/common/cpt-messages.php
@@ -273,28 +273,21 @@ function cpt_process_new_message() {
     // Figures out whether to send the full content of this message.
     $send_msg_content_default = get_option( 'cpt_send_message_content' );
 
-    switch ( $send_msg_content_default ) {
+    if ( ! $send_msg_content_default ) {
 
-      case ( $send_msg_content_default == true ):
+      if ( isset( $_POST[ 'send_message_content' ] ) && $_POST[ 'send_message_content' ] == 1 ) {
+        $send_this_msg_content = true;
+      } else {
+        $send_this_msg_content = false;
+      }
 
-        if ( isset( $_POST[ 'send_notification_only' ] ) && $_POST[ 'send_notification_only' ] == 1 ) {
-          $send_this_msg_content = false;
-        } else {
-          $send_this_msg_content = true;
-        }
+    } else {
 
-        break;
-
-      case ( $send_msg_content_default == false ):
-      default:
-
-        if ( isset( $_POST[ 'send_message_content' ] ) && $_POST[ 'send_message_content' ] == 1 ) {
-          $send_this_msg_content = true;
-        } else {
-          $send_this_msg_content = false;
-        }
-
-        break;
+      if ( isset( $_POST[ 'send_notification_only' ] ) && $_POST[ 'send_notification_only' ] == 1 ) {
+        $send_this_msg_content = false;
+      } else {
+        $send_this_msg_content = true;
+      }
 
     }
 
@@ -342,7 +335,7 @@ function cpt_process_new_message() {
 
 }
 
-// add_action( 'admin_post_cpt_new_message_added', __NAMESPACE__ . '\cpt_process_new_message' );
+add_action( 'admin_post_cpt_new_message_added', __NAMESPACE__ . '\cpt_process_new_message' );
 
 
 function cpt_message_notification( $message_id ) {

--- a/common/cpt-messages.php
+++ b/common/cpt-messages.php
@@ -6,10 +6,10 @@ function cpt_messages( $user_id ) {
 
   if ( ! $user_id ) { return; }
 
-  echo '<h2>Messages</h2>';
+  echo '<h2>' . __( 'Messages' ) . '</h2>';
   cpt_message_list( $user_id );
 
-  echo '<h2>New Message</h2>';
+  echo '<h2>' . __( 'New Message' ) . '</h2>';
   echo '<div id="cpt-new-message-form">';
     cpt_new_message_form( $user_id );
   echo '</div>';
@@ -48,19 +48,19 @@ function cpt_message_list( $user_id ) {
 
             case ( get_current_user_id() ):
               $message_classes[]   = 'my-message';
-              $message_meta       .= 'Sent';
+              $message_meta       .= __( 'Sent' );
 
               break;
 
             case ( $user_id ):
               $message_classes[]   = 'client-message not-my-message';
-              $message_meta       .= 'Received from ' . get_the_author();
+              $message_meta       .= __( 'Received from' ) . ' ' . get_the_author();
 
               break;
 
             default:
               $message_classes[]   = 'not-my-message';
-              $message_meta       .= 'Sent by ' . get_the_author();
+              $message_meta       .= __( 'Sent by' ) . ' ' . get_the_author();
 
           }
 
@@ -105,11 +105,7 @@ function cpt_message_list( $user_id ) {
 
   else :
 
-    ?>
-
-      <p>No messages found.</p>
-
-    <?php
+    echo '<p>' . __( 'No messages found.' ) . '</p>';
 
   endif;
 
@@ -143,16 +139,16 @@ function cpt_new_message_form( $user_id ) {
             <tbody>
               <tr>
                 <th scope="row">
-                  <label for="subject_line">Subject Line</label>
+                  <label for="subject_line"><?php _e( 'Subject Line' ); ?></label>
                 </th>
                 <td>
                   <input name="subject_line" id="subject_line" class="large-text" type="text">
-                  <p>If you leave this field empty, the subject line will be "New message from <?php echo get_the_author(); ?>."</p>
+                  <p><?php echo __( 'If you leave this field empty, the subject line will be "New message from' ) . ' ' . get_the_author() . '."'; ?></p>
                 </td>
               </tr>
               <tr>
                 <th scope="row">
-                  <label for="message">Message</label>
+                  <label for="message"><?php _e( 'Message' ); ?></label>
                 </th>
                 <td>
                   <?php \wp_editor( '', 'cpt-message-editor', $editor_args ); ?>
@@ -161,10 +157,10 @@ function cpt_new_message_form( $user_id ) {
             </tbody>
           </table>
 
-          <p>When you click send, this client will receive an email letting them know they have a message, but they will have to log into their client dashboard to view the body of the message.</p>
+          <p><?php _e( 'When you click send, this client will receive an email letting them know they have a message, but they will have to log into their client dashboard to view the body of the message.' ); ?></p>
 
           <p class="submit">
-            <input name="submit" id="submit" class="button button-primary" type="submit" value="Send Message">
+            <input name="submit" id="submit" class="button button-primary" type="submit" value="<?php _e( 'Send Message' ); ?>">
           </p>
 
         </form>
@@ -204,7 +200,7 @@ function cpt_new_message_form( $user_id ) {
             */
             echo sprintf(
               '<p>%s %s</p>',
-              sprintf( '<label for="subject_line">Subject Line<br /><small>(optional)</small></label>' ),
+              sprintf( '<label for="subject_line">' . _( 'Subject Line' ) . '<br /><small>' . __( '(optional)' ) . '</small></label>' ),
               sprintf( '<input name="subject_line" id="subject_line" class="large-text" type="text">' ),
             );
 
@@ -217,14 +213,14 @@ function cpt_new_message_form( $user_id ) {
             */
             echo sprintf(
               '<p style="margin-bottom: 0 !important;">%s</p>%s<p style="line-height: 0 !important;"> </p>',
-              sprintf( '<label for="message">Message<br /><small>(required)</small></label>' ),
+              sprintf( '<label for="message">' . __( 'Message' ) . '<br /><small>' . __( '(required)' ) . '</small></label>' ),
               sprintf( $message_editor ),
             );
 
           ?>
 
           <p class="submit">
-            <input name="submit" id="submit" class="button button-primary" type="submit" value="Send Message">
+            <input name="submit" id="submit" class="button button-primary" type="submit" value="<?php _e( 'Send Message' ); ?>">
           </p>
 
         </form>
@@ -268,13 +264,13 @@ function cpt_process_new_message() {
 
     if ( is_wp_error( $post ) ) {
 
-      $result = 'Message could not be sent. Error message: ' . $post->get_error_message();
+      $result = __( 'Message could not be sent. Error message:' ) . ' ' . $post->get_error_message();
 
     } else {
 
       cpt_message_notification( $post );
 
-      $result = 'Message sent!';
+      $result = __( 'Message sent!' );
 
     }
 
@@ -310,21 +306,21 @@ function cpt_message_notification( $message_id ) {
   $headers[]        = 'From: ' . $from_name . ' <' . $from_email . '>';
 
   $to               = $client_obj->user_email;
-  $subject          = $msg_obj->post_title ? $msg_obj->post_title : 'You have a new message from ' . $from_name;
+  $subject          = $msg_obj->post_title ? $msg_obj->post_title : __( 'You have a new message from' ) . ' ' . $from_name;
 
   if ( $sender_id == $clients_user_id ) {
 
-    $message      = '<p>To read your message, please visit your client dashboard.</p>';
+    $message      = '<p>' . __( 'To read your message, please visit your client dashboard.' ) . '</p>';
     $button_url   = cpt_get_client_profile_url( $clients_user_id ) . '#cpt-message-' . $message_id;
 
   } else {
 
-    $message      = '<p>To read this message, please view the client page.</p>';
+    $message      = '<p>' . __( 'To read this message, please view the client page.' ) . '</p>';
     $button_url   = cpt_get_client_dashboard_url() . '#cpt-message-' . $message_id;
 
   }
 
-  $button_txt     = 'Go to Message';
+  $button_txt     = __( 'Go to Message' );
 
   $message = cpt_get_email_card( $subject, $message, $button_txt, $button_url );
 

--- a/readme.txt
+++ b/readme.txt
@@ -71,6 +71,19 @@ This release adds one important feature. Now you can delete clients from the cli
 ### Added
 - Delete a client from the client's profile page, under **Edit Client**.
 
+= 1.0.5 =
+
+### Changed
+- Handle frontend login error on the front end.
+- General tidying up.
+
+### Removed
+- Remove unused capabilities from Client Manager role (for now).
+- Remove unused functions cpt_get_client_profile_link and cpt_get_client_id.
+
+### Fixed
+- Email notifications should now deliver with the intended formatting.
+
 
 == Installation ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -61,15 +61,31 @@ Client Power Tools is built to be customizable where you need it to be. Here are
 
 == Upgrade Notice ==
 
-This release adds one important feature. Now you can delete clients from the client's profile page, under **Edit Client**!
+This release adds several user-requested features. In settings, now you can disable the status request button entirely. You can also change the default email notification behavior to include the full message, rather than just a notification, but you can override this default on individual messages.
+
+Finally, when you try to add a new client when there is already a WordPress user account with the same email address, the user is simply given the Client role rather than returning an error. (The documentation will be updated, as well.)
+
+There's also a bunch of smaller tweaks and improvements.
 
 
 == Changelog ==
+
+### [1.2.0]
+
+#### Added
+- Setting to disable the status request button entirely.
+- Setting to change the default email notification behavior to include the full message, rather than just a notification.
+- Override the default email behavior on individual messages.
+
+#### Changed
+- Creating a new client with an existing user's email address now adds the Client role to the existing user instead of returning an error.
+
 
 ### 1.1.0
 
 #### Added
 - Delete a client from the client's profile page, under **Edit Client**.
+
 
 ### 1.0.5
 

--- a/readme.txt
+++ b/readme.txt
@@ -66,12 +66,12 @@ This release adds one important feature. Now you can delete clients from the cli
 
 == Changelog ==
 
-= 1.1.0 =
+### 1.1.0
 
 #### Added
 - Delete a client from the client's profile page, under **Edit Client**.
 
-= 1.0.5 =
+### 1.0.5
 
 #### Changed
 - Handle frontend login error on the front end.

--- a/readme.txt
+++ b/readme.txt
@@ -68,20 +68,20 @@ This release adds one important feature. Now you can delete clients from the cli
 
 = 1.1.0 =
 
-### Added
+#### Added
 - Delete a client from the client's profile page, under **Edit Client**.
 
 = 1.0.5 =
 
-### Changed
+#### Changed
 - Handle frontend login error on the front end.
 - General tidying up.
 
-### Removed
+#### Removed
 - Remove unused capabilities from Client Manager role (for now).
 - Remove unused functions cpt_get_client_profile_link and cpt_get_client_id.
 
-### Fixed
+#### Fixed
 - Email notifications should now deliver with the intended formatting.
 
 


### PR DESCRIPTION
This release adds several user-requested features. In settings, now you can disable the status request button entirely. You can also change the default email notification behavior to include the full message, rather than just a notification, but you can override this default on individual messages.

Finally, when you try to add a new client when there is already a WordPress user account with the same email address, the user is simply given the Client role rather than returning an error. (The documentation will be updated, as well.)

There's also a bunch of smaller tweaks and improvements.

#### Added
- Setting to disable the status request button entirely.
- Setting to change the default email behavior to include the full message, rather than just a notification.
- Override the default email behavior on individual messages.

#### Changed
- Creating a new client with an existing user's email address now adds the Client role to the existing user instead of returning an error.