### PR TITLE
Version 1.3

### DIFF
--- a/admin/cpt-admin-messages-table.php
+++ b/admin/cpt-admin-messages-table.php
@@ -58,19 +58,10 @@ class Message_List_Table extends Includes\WP_List_Table  {
   */
   function column_client( $item ) {
 
-    $clients_url  = esc_url( admin_url( 'admin.php?page=cpt' ) );
-    $client_url   = add_query_arg( 'user_id', $item[ 'clients_user_id' ], $clients_url );
-
-    // Build row actions.
-    $actions = [
-      'view_client'   => sprintf( '<a href="' . $client_url . '">View Client</a>' ),
-    ];
-
     // Return the contents.
-    return sprintf( '<strong>%1$s</strong>%2$s<br />%3$s',
+    return sprintf( '<strong>%1$s</strong>%2$s',
       /* $1%s */ $item[ 'client_name' ],
       /* $2%s */ $item[ 'client_id' ] ? ' <span style="color:silver">(' . $item[ 'client_id' ] . ')</span>' : '',
-      /* $3%s */ $this->row_actions( $actions, true )
     );
 
   }
@@ -91,16 +82,10 @@ class Message_List_Table extends Includes\WP_List_Table  {
     $clients_url  = add_query_arg( 'user_id', $item[ 'clients_user_id' ], esc_url( admin_url( 'admin.php?page=cpt' ) ) );
     $msg_url      = $clients_url . '#cpt-message-' . $item[ 'ID' ];
 
-    // Build row actions.
-    $actions = [
-      'goto_msg'   => sprintf( '<a href="' . $msg_url . '">Go to Message</a>' ),
-    ];
-
     // Return the contents.
-    return sprintf( '<strong><a href="%1$s">%2$s</a></strong><br />%3$s',
+    return sprintf( '<strong><a href="%1$s">%2$s</a></strong>',
       /* $1%s */ $msg_url,
       /* $2%s */ $item[ 'subject' ],
-      /* $3%s */ $this->row_actions( $actions )
     );
 
   }

--- a/admin/cpt-admin-messages-table.php
+++ b/admin/cpt-admin-messages-table.php
@@ -229,7 +229,7 @@ class CLIENT_POWER_TOOLS_Message_List_Table extends Includes\WP_List_Table  {
 
       $data[] = [
         'ID'              => $post_id,
-        'client_name'     => Common\cpt_get_client_name( $clients_user_id ),
+        'client_name'     => Common\cpt_get_name( $clients_user_id ),
         'clients_user_id' => $clients_user_id,
         'client_id'       => get_user_meta( $clients_user_id, 'cpt_client_id', true ),
         'sender'          => get_the_author(),

--- a/admin/cpt-admin-messages-table.php
+++ b/admin/cpt-admin-messages-table.php
@@ -9,7 +9,7 @@ namespace Client_Power_Tools\Core\Admin;
 use Client_Power_Tools\Core\Common;
 use Client_Power_Tools\Core\Includes;
 
-class CLIENT_POWER_TOOLS_Message_List_Table extends Includes\WP_List_Table  {
+class Message_List_Table extends Includes\WP_List_Table  {
 
   function __construct() {
 
@@ -70,7 +70,7 @@ class CLIENT_POWER_TOOLS_Message_List_Table extends Includes\WP_List_Table  {
     return sprintf( '<strong>%1$s</strong>%2$s<br />%3$s',
       /* $1%s */ $item[ 'client_name' ],
       /* $2%s */ $item[ 'client_id' ] ? ' <span style="color:silver">(' . $item[ 'client_id' ] . ')</span>' : '',
-      /* $3%s */ $this->row_actions( $actions )
+      /* $3%s */ $this->row_actions( $actions, true )
     );
 
   }

--- a/admin/cpt-admin-messages.php
+++ b/admin/cpt-admin-messages.php
@@ -34,7 +34,7 @@ function cpt_get_message_list() {
 
   ob_start();
 
-    $message_list = new CLIENT_POWER_TOOLS_Message_List_Table();
+    $message_list = new Message_List_Table();
     $message_list->prepare_items();
 
     ?>

--- a/admin/cpt-admin.css
+++ b/admin/cpt-admin.css
@@ -69,7 +69,8 @@
     align-self: center;
   }
 
-  #cpt-admin-page-title p#cpt-client-status {
+  #cpt-admin-page-title p#cpt-client-status,
+  #cpt-admin-page-title p#cpt-client-manager {
     font-size: 16px;
     line-height: 1.1;
     margin: 0;

--- a/admin/cpt-admin.js
+++ b/admin/cpt-admin.js
@@ -1,23 +1,5 @@
 ( function( $ ) {
 
-  $( '#cpt-admin .cpt-click-to-expand' ).click( function() {
-
-    switch ( $( this ).html() ) {
-
-      case 'Edit Client':
-        $( this ).html( 'Cancel' );
-        break;
-
-      case 'Cancel':
-      default:
-        $( this ).html( 'Edit Client' );
-        break;
-
-    }
-
-  });
-
-
   // Admin Delete-Client Warning
   let deleteClientLink    = $( '#cpt-delete-client-link' );
 

--- a/admin/cpt-admin.php
+++ b/admin/cpt-admin.php
@@ -73,11 +73,11 @@ function cpt_menu_pages() {
 
   add_submenu_page(
     'cpt',
-    'Client Power Tools: Add New Client',
-    'Add Client',
-    'cpt-manage-clients',
-    'cpt-new-client',
-    __NAMESPACE__ . '\cpt_new_client',
+    'Client Power Tools: Client Managers',
+    'Managers',
+    'cpt-manage-settings',
+    'cpt-managers',
+    __NAMESPACE__ . '\cpt_client_managers',
   );
 
   add_submenu_page(

--- a/admin/cpt-admin.php
+++ b/admin/cpt-admin.php
@@ -120,10 +120,61 @@ function cpt_get_admin_notices( $transient_key ) {
 add_action( 'admin_notices', __NAMESPACE__ . '\cpt_get_admin_notices' );
 
 
-function cpt_get_client_statuses_select( $name = 'cpt_client_statuses' ) {
+function cpt_get_client_manager_select( $name = null, $selected = null ) {
 
-  $statuses_array   = explode( "\n", get_option( 'cpt_client_statuses' ) );
-  $default_status   = get_option( 'cpt_default_client_status' );
+  if ( ! $name ) {
+    $name = 'client_manager';
+  }
+
+  if ( ! $selected ) {
+    $admin    = get_user_by_email( get_bloginfo( 'admin_email' ) );
+    $selected = get_option( 'cpt_default_client_manager' ) ? get_option( 'cpt_default_client_manager' ) : $admin->ID;
+  }
+
+  /**
+  * Query Client Managers
+  */
+  $args = [
+    'role__in'  => [ 'administrator', 'cpt-client-manager' ],
+    'orderby'   => 'display_name',
+    'order'     => 'ASC',
+  ];
+
+  $client_manager_query = new \WP_USER_QUERY( $args );
+  $client_managers      = $client_manager_query->get_results();
+
+  ob_start();
+
+    echo '<select name="' . $name . '" id="' . $name . '">';
+
+    foreach ( $client_managers as $client_manager ) {
+      echo '<option value="' . $client_manager->ID . '"';
+
+      if ( $client_manager->ID == $selected ) {
+        echo ' selected';
+      }
+
+      echo '>' . $client_manager->display_name . '</option>';
+    }
+
+    echo '</select>';
+
+  return ob_get_clean();
+
+}
+
+
+function cpt_get_client_statuses_select( $name = null, $selected = null ) {
+
+  $statuses_array = explode( "\n", get_option( 'cpt_client_statuses' ) );
+
+  if ( ! $name ) {
+    $name = 'client_status';
+  }
+
+  if ( ! $selected ) {
+    $selected = get_option( 'cpt_default_client_status' );
+  }
 
   ob_start();
 
@@ -133,7 +184,7 @@ function cpt_get_client_statuses_select( $name = 'cpt_client_statuses' ) {
 
       echo '<option value="' . $status . '"';
 
-      if ( trim( $status ) == $default_status ) {
+      if ( trim( $status ) == $selected ) {
         echo ' selected';
       }
 

--- a/admin/cpt-admin.php
+++ b/admin/cpt-admin.php
@@ -29,7 +29,7 @@ function cpt_security_warning() {
     ?>
 
       <div class="cpt-notice notice notice-warning">
-        <p><?php _e( '<strong>Warning!</strong> It doesn\'t look like your website is using SSL (HTTPS) for security. Before using Client Power Tools with your clients, you should get an SSL certificate for your website and consider additional security precautions. <a href="https://clientpowertools.com/security/?utm_source=cpt_user&utm_medium=cpt_ssl_warning" target="_blank">Learn more.</a>' ); ?></p>
+        <p><?php _e( '<strong>Warning!</strong> It doesn\'t look like your website is using SSL (HTTPS). Before using Client Power Tools with your clients, it\'s a good idea to get an SSL certificate for your website and consider additional security measures. <a href="https://clientpowertools.com/security/?utm_source=cpt_user&utm_medium=cpt_ssl_warning" target="_blank">Learn more.</a>' ); ?></p>
       </div>
 
     <?php

--- a/admin/cpt-admin.php
+++ b/admin/cpt-admin.php
@@ -66,7 +66,7 @@ function cpt_menu_pages() {
     'cpt',
     'Client Power Tools: Messages',
     'Messages',
-    'cpt-manage-clients',
+    'cpt-view-clients',
     'cpt-messages',
     __NAMESPACE__ . '\cpt_admin_messages',
   );

--- a/admin/cpt-admin.php
+++ b/admin/cpt-admin.php
@@ -29,7 +29,7 @@ function cpt_security_warning() {
     ?>
 
       <div class="cpt-notice notice notice-warning">
-        <p><?php _e( '<strong>Warning!</strong> It doesn\'t look like your website is using SSL (HTTPS) for security. Before using Client Power Tools with your clients, you should get an SSL certificate for your website and consider additional security precautions. <a href="https://clientpowertools.com/security/?utm_source=cpt_user&utm_medium=cpt_ssl_warning">Learn more.</a>' ); ?></p>
+        <p><?php _e( '<strong>Warning!</strong> It doesn\'t look like your website is using SSL (HTTPS) for security. Before using Client Power Tools with your clients, you should get an SSL certificate for your website and consider additional security precautions. <a href="https://clientpowertools.com/security/?utm_source=cpt_user&utm_medium=cpt_ssl_warning" target="_blank">Learn more.</a>' ); ?></p>
       </div>
 
     <?php

--- a/admin/cpt-admin.php
+++ b/admin/cpt-admin.php
@@ -75,7 +75,7 @@ function cpt_menu_pages() {
     'cpt',
     'Client Power Tools: Client Managers',
     'Managers',
-    'cpt-manage-settings',
+    'cpt-manage-team',
     'cpt-managers',
     __NAMESPACE__ . '\cpt_client_managers',
   );
@@ -135,7 +135,7 @@ function cpt_get_client_manager_select( $name = null, $selected = null ) {
   * Query Client Managers
   */
   $args = [
-    'role__in'  => [ 'administrator', 'cpt-client-manager' ],
+    'role__in'  => [ 'cpt-client-manager' ],
     'orderby'   => 'display_name',
     'order'     => 'ASC',
   ];

--- a/admin/cpt-client-manager-table.php
+++ b/admin/cpt-client-manager-table.php
@@ -78,18 +78,26 @@ class Client_Manager_List_Table extends Includes\WP_List_Table  {
 
     $managers_client_data = cpt_get_managers_clients( $item[ 'ID' ] );
 
-    foreach ( $managers_client_data as $client_data ) {
+    if ( $managers_client_data ) {
 
-      $client = Common\cpt_get_name( $client_data[ 'user_id' ] );
+      foreach ( $managers_client_data as $client_data ) {
 
-      if ( $client_data[ 'client_id' ] ) {
-        $client .= ' <span style="color:silver">(' . $client_data[ 'client_id' ] . ')</span>';
+        $client = Common\cpt_get_name( $client_data[ 'user_id' ] );
+
+        if ( $client_data[ 'client_id' ] ) {
+          $client .= ' <span style="color:silver">(' . $client_data[ 'client_id' ] . ')</span>';
+        }
+
+        $clients[] = $client;
       }
 
-      $clients[] = $client;
-    }
+      return implode( '<br/>' . "\n", $clients );
 
-    return implode( '<br/>' . "\n", $clients );
+    } else {
+
+      return '<span style="color:silver">None</span>';
+
+    }
 
   }
 

--- a/admin/cpt-client-manager-table.php
+++ b/admin/cpt-client-manager-table.php
@@ -82,7 +82,10 @@ class Client_Manager_List_Table extends Includes\WP_List_Table  {
 
       foreach ( $managers_client_data as $client_data ) {
 
-        $client = Common\cpt_get_name( $client_data[ 'user_id' ] );
+        $clients_url  = esc_url( admin_url( 'admin.php?page=cpt' ) );
+        $client_url   = add_query_arg( 'user_id', $client_data[ 'user_id' ], $clients_url );
+
+        $client       = '<a href="' . $client_url . '">' . Common\cpt_get_name( $client_data[ 'user_id' ] ) . '</a>';
 
         if ( $client_data[ 'client_id' ] ) {
           $client .= ' <span style="color:silver">(' . $client_data[ 'client_id' ] . ')</span>';

--- a/admin/cpt-client-manager-table.php
+++ b/admin/cpt-client-manager-table.php
@@ -55,21 +55,19 @@ class Client_Manager_List_Table extends Includes\WP_List_Table  {
   /**
   * Name Column Method
   */
-  function column_client_manager_name( $item ) {
+  function column_manager_name( $item ) {
 
-    // Build row actions.
     $actions = [
-      'remove' => '<a href="' . add_query_arg( 'user_id', $item[ 'ID' ] ) . '">Remove</a>',
+      'remove' => '<a href="' . add_query_arg( [ 'user_id' => $item[ 'ID' ], 'cpt_action' => 'cpt_remove_client_manager' ] ) . '">Remove</a>',
     ];
 
     // Return the contents.
     return sprintf( '<strong>%1$s</strong><br />%2$s',
       /* $1%s */ $item[ 'manager_name' ],
-      /* $2%s */ $this->row_actions( $actions )
+      /* $2%s */ $this->row_actions( $actions, true )
     );
 
   }
-
 
   /**
   * Get Columns
@@ -83,7 +81,6 @@ class Client_Manager_List_Table extends Includes\WP_List_Table  {
     $columns = [
       // 'cb'              => '<input type="checkbox" />',
       'manager_name'     => 'Manager Name',
-      'manager_email'    => 'Email Address',
     ];
 
     return $columns;
@@ -176,8 +173,6 @@ class Client_Manager_List_Table extends Includes\WP_List_Table  {
 
     // Creates the data set.
     if ( ! empty( $client_managers ) ) {
-
-      var_dump( $client_managers );
 
       foreach ( $client_managers as $client_manager ) {
 

--- a/admin/cpt-client-manager-table.php
+++ b/admin/cpt-client-manager-table.php
@@ -60,7 +60,6 @@ class Client_Manager_List_Table extends Includes\WP_List_Table  {
 
     $actions = [
       'remove'    => '<a href="' . add_query_arg( [ 'user_id' => $item[ 'ID' ], 'cpt_action' => 'cpt_remove_client_manager' ] ) . '">Remove</a>',
-      'reassign'  => '<a href="' . add_query_arg( [ 'user_id' => $item[ 'ID' ], 'cpt_action' => 'cpt_reassign_client_manager' ] ) . '">Reassign All Clients</a>',
     ];
 
     // Return the contents.

--- a/admin/cpt-client-manager-table.php
+++ b/admin/cpt-client-manager-table.php
@@ -220,6 +220,12 @@ class Client_Manager_List_Table extends Includes\WP_List_Table  {
 
     }
 
+    // Sorts the data set.
+    $orderby  = isset( $_REQUEST[ 'orderby' ] )  ? sanitize_key( $_REQUEST[ 'orderby' ] )  : 'display_name';
+    $order    = isset( $_REQUEST[ 'order' ] )    ? sanitize_key( $_REQUEST[ 'order' ] )    : 'ASC';
+
+    $data     = wp_list_sort( $data, $orderby, $order );
+
     /**
     * Pagination
     */

--- a/admin/cpt-client-manager-table.php
+++ b/admin/cpt-client-manager-table.php
@@ -6,6 +6,7 @@
 */
 
 namespace Client_Power_Tools\Core\Admin;
+use Client_Power_Tools\Core\Common;
 use Client_Power_Tools\Core\Includes;
 
 class Client_Manager_List_Table extends Includes\WP_List_Table  {
@@ -74,7 +75,22 @@ class Client_Manager_List_Table extends Includes\WP_List_Table  {
   * Clients Column Method
   */
   function column_managers_clients( $item ) {
-    echo var_dump( cpt_get_managers_clients( $item[ 'ID' ] ) );
+
+    $managers_client_data = cpt_get_managers_clients( $item[ 'ID' ] );
+
+    foreach ( $managers_client_data as $client_data ) {
+
+      $client = Common\cpt_get_name( $client_data[ 'user_id' ] );
+
+      if ( $client_data[ 'client_id' ] ) {
+        $client .= ' <span style="color:silver">(' . $client_data[ 'client_id' ] . ')</span>';
+      }
+
+      $clients[] = $client;
+    }
+
+    return implode( '<br/>' . "\n", $clients );
+
   }
 
 

--- a/admin/cpt-client-manager-table.php
+++ b/admin/cpt-client-manager-table.php
@@ -69,6 +69,15 @@ class Client_Manager_List_Table extends Includes\WP_List_Table  {
 
   }
 
+
+  /**
+  * Clients Column Method
+  */
+  function column_managers_clients( $item ) {
+    echo var_dump( cpt_get_managers_clients( $item[ 'ID' ] ) );
+  }
+
+
   /**
   * Get Columns
   *
@@ -80,7 +89,8 @@ class Client_Manager_List_Table extends Includes\WP_List_Table  {
 
     $columns = [
       // 'cb'              => '<input type="checkbox" />',
-      'manager_name'     => 'Manager Name',
+      'manager_name'      => 'Manager Name',
+      'managers_clients'  => 'Clients',
     ];
 
     return $columns;

--- a/admin/cpt-client-manager-table.php
+++ b/admin/cpt-client-manager-table.php
@@ -1,0 +1,219 @@
+<?php
+
+/**
+* This is based on the Custom List Table Example plugin by Matt van Andel.
+* https://wordpress.org/plugins/custom-list-table-example/
+*/
+
+namespace Client_Power_Tools\Core\Admin;
+use Client_Power_Tools\Core\Includes;
+
+class Client_Manager_List_Table extends Includes\WP_List_Table  {
+
+  function __construct() {
+
+    global $page;
+
+    parent::__construct( [
+      'singular'  => 'manager',
+      'plural'    => 'managers',
+      'ajax'      => false,
+    ]);
+
+  }
+
+  /**
+  * Column Default
+  *
+  * @param array $item A singular item (one full row's worth of data)
+  * @param array $column_name The name/slug of the column to be processed
+  * @return string Text or HTML to be placed inside the column <td>
+  */
+  function column_default( $item, $column_name ) {
+    return;
+  }
+
+
+  /**
+  * Checkboxes
+  *
+  * @see WP_List_Table::::single_row_columns()
+  * @param array $item A singular item (one full row's worth of data)
+  * @return string Text to be placed inside the column <td>
+  */
+  function column_cb( $item ) {
+
+    return sprintf(
+      '<input type="checkbox" name="%1$s[]" value="%2$s" />',
+      /* $1%s */ $this->_args[ 'singular' ],
+      /* $2%s */ $item[ 'ID' ]
+    );
+
+  }
+
+
+  /**
+  * Name Column Method
+  */
+  function column_client_manager_name( $item ) {
+
+    // Build row actions.
+    $actions = [
+      'remove' => '<a href="' . add_query_arg( 'user_id', $item[ 'ID' ] ) . '">Remove</a>',
+    ];
+
+    // Return the contents.
+    return sprintf( '<strong>%1$s</strong><br />%2$s',
+      /* $1%s */ $item[ 'manager_name' ],
+      /* $2%s */ $this->row_actions( $actions )
+    );
+
+  }
+
+
+  /**
+  * Get Columns
+  *
+  * @see WP_List_Table::::single_row_columns()
+  * @return array An associative array containing column information:
+  * 'slugs' => 'Visible Titles'.
+  */
+  function get_columns() {
+
+    $columns = [
+      // 'cb'              => '<input type="checkbox" />',
+      'manager_name'     => 'Manager Name',
+      'manager_email'    => 'Email Address',
+    ];
+
+    return $columns;
+
+  }
+
+
+  /**
+  * Sortable Columns
+  */
+  function get_sortable_columns() {
+
+    $sortable_columns = [
+      'manager_name' => [ 'manager_name', true ],
+    ];
+
+    return $sortable_columns;
+
+  }
+
+
+  /**
+  * Bulk Actions
+  *
+  * @return array An associative array containing all the bulk actions: 'slugs'=>'Visible Titles'
+  */
+  function get_bulk_actions() {
+
+    return; // Remove this line to enable bulk actions.
+
+    $actions = [
+      'remove'  => 'remove',
+    ];
+
+    return $actions;
+
+  }
+
+
+  function process_bulk_action() {
+
+    $action = $this->current_action();
+
+    switch ( $action ) {
+
+      case 'remove':
+        wp_die( 'Remove client manager permissions.' );
+        break;
+
+      default:
+        return;
+        break;
+
+    }
+
+    return;
+
+  }
+
+
+  /**
+  * Prepare Data for Display
+  */
+  function prepare_items() {
+
+    /**
+    * Column Headers
+    */
+    $columns  = $this->get_columns();
+    $hidden   = [];
+    $sortable = $this->get_sortable_columns();
+
+    $this->_column_headers = [ $columns, $hidden, $sortable ];
+
+    $this->process_bulk_action();
+
+
+    /**
+    * Query Client Managers
+    */
+    $args = [
+      'role'      => 'cpt-client-manager',
+      'orderby'   => 'display_name',
+      'order'     => 'ASC',
+    ];
+
+    $client_managers_query  = new \WP_USER_QUERY( $args );
+    $client_managers        = $client_managers_query->get_results();
+    $data                   = [];
+
+    // Creates the data set.
+    if ( ! empty( $client_managers ) ) {
+
+      var_dump( $client_managers );
+
+      foreach ( $client_managers as $client_manager ) {
+
+        $data[] = [
+          'ID'            => $client_manager->ID,
+          'manager_name'  => $client_manager->display_name,
+          'manager_email' => $client_manager->user_email,
+        ];
+
+      }
+
+    }
+
+    /**
+    * Pagination
+    */
+    $total_items  = count( $data );
+    $per_page     = 25;
+    $current_page = $this->get_pagenum();
+    $data         = array_slice( $data, ( ( $current_page - 1 ) * $per_page ), $per_page );
+
+    $this->set_pagination_args(
+      [
+        'total_items' => $total_items,
+        'per_page'    => $per_page,
+        'total_pages' => ceil( $total_items / $per_page ),
+      ],
+    );
+
+
+    /**
+    * $this->items contains the data that will actually be displayed on the
+    * current page.
+    */
+    $this->items = $data;
+
+  }
+
+}

--- a/admin/cpt-client-manager-table.php
+++ b/admin/cpt-client-manager-table.php
@@ -59,13 +59,14 @@ class Client_Manager_List_Table extends Includes\WP_List_Table  {
   function column_manager_name( $item ) {
 
     $actions = [
-      'remove' => '<a href="' . add_query_arg( [ 'user_id' => $item[ 'ID' ], 'cpt_action' => 'cpt_remove_client_manager' ] ) . '">Remove</a>',
+      'remove'    => '<a href="' . add_query_arg( [ 'user_id' => $item[ 'ID' ], 'cpt_action' => 'cpt_remove_client_manager' ] ) . '">Remove</a>',
+      'reassign'  => '<a href="' . add_query_arg( [ 'user_id' => $item[ 'ID' ], 'cpt_action' => 'cpt_reassign_client_manager' ] ) . '">Reassign All Clients</a>',
     ];
 
     // Return the contents.
     return sprintf( '<strong>%1$s</strong><br />%2$s',
       /* $1%s */ $item[ 'manager_name' ],
-      /* $2%s */ $this->row_actions( $actions, true )
+      /* $2%s */ $this->row_actions( $actions )
     );
 
   }

--- a/admin/cpt-client-managers.php
+++ b/admin/cpt-client-managers.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Client_Power_Tools\Core\Admin;
+use Client_Power_Tools\Core\Common;
+
+function cpt_client_managers() {
+
+  if ( ! current_user_can( 'cpt-manage-settings' ) ) {
+    wp_die(
+      '<p>' . __( 'Sorry, you are not allowed to access this page.' ) . '</p>',
+      403
+    );
+  }
+
+  Common\cpt_get_notices( 'cpt_add_manager_result' );
+  Common\cpt_get_notices( 'cpt_remove_manager_result' );
+
+  ob_start();
+
+    ?>
+
+      <div id="cpt-admin" class="wrap">
+
+        <div id="cpt-admin-header">
+          <img src="<?php echo CLIENT_POWER_TOOLS_DIR_URL; ?>admin/images/cpt-logo.svg" height="auto" width="100%" />
+          <div id="cpt-admin-page-title">
+            <h1 id="cpt-page-title">Client Managers</h1>
+            <p id="cpt-subtitle">Client Power Tools</p>
+          </div>
+        </div>
+        <hr class="wp-header-end">
+
+        <button class="button cpt-click-to-expand"><?php _e( 'Add a Client Manager' ); ?></button>
+
+        <div class="cpt-this-expands">
+          <?php cpt_add_client_manager_form(); ?>
+        </div>
+
+        <?php cpt_client_manager_list(); ?>
+
+      </div>
+
+    <?php
+
+  echo ob_get_clean();
+
+}
+
+
+function cpt_add_client_manager_form() {
+
+  ob_start();
+
+    ?>
+
+      <h4>Add a Client Manager</h4>
+
+      <p><?php _e( 'Assign the client manager role to a new or existing user. Add the first and last name as you want clients to see them.' ); ?></p>
+
+      <form action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" method="POST">
+
+        <?php wp_nonce_field( 'cpt_client_manager_added', 'cpt_client_manager_nonce' ); ?>
+        <input name="action" value="cpt_client_manager_added" type="hidden">
+
+        <table class="form-table" role="presentation">
+          <tbody>
+            <tr>
+              <th scope="row">
+                <label for="first_name">First Name<br /><small>(required)</small></label>
+              </th>
+              <td>
+                <input name="first_name" id="first_name" class="regular-text" type="text" data-required="true">
+              </td>
+            </tr>
+            <tr>
+              <th scope="row">
+                <label for="last_name">Last Name<br /><small>(required)</small></label>
+              </th>
+              <td>
+                <input name="last_name" id="last_name" class="regular-text" type="text" data-required="true">
+              </td>
+            </tr>
+            <tr>
+              <th scope="row">
+                <label for="email">Email Address<br /><small>(required)</small></label>
+              </th>
+              <td>
+                <input name="email" id="email" class="regular-text" type="text" data-required="true" autocapitalize="none" autocorrect="off">
+              </td>
+          </tbody>
+        </table>
+
+        <p class="submit">
+          <input name="submit" id="submit" class="button button-primary" type="submit" value="Add Client Manager">
+        </p>
+
+      </form>
+
+    <?php
+
+  echo ob_get_clean();
+
+}
+
+
+function cpt_client_manager_list() {
+
+  ob_start();
+
+    $client_manager_list = new Client_Manager_List_Table();
+    $client_manager_list->prepare_items();
+
+    ?>
+
+      <form id="client-manager-list" method="get">
+        <?php $client_manager_list->views(); ?>
+        <?php $client_manager_list->display() ?>
+      </form>
+
+    <?php
+
+  echo ob_get_clean();
+
+}

--- a/admin/cpt-client-managers.php
+++ b/admin/cpt-client-managers.php
@@ -12,8 +12,14 @@ function cpt_client_managers() {
     );
   }
 
-  Common\cpt_get_notices( 'cpt_add_manager_result' );
-  Common\cpt_get_notices( 'cpt_remove_manager_result' );
+  if ( isset( $_POST[ 'cpt_new_client_manager_nonce' ] ) && wp_verify_nonce( $_POST[ 'cpt_new_client_manager_nonce' ], 'cpt_new_client_manager_added' )  ) {
+    
+  }
+
+  Common\cpt_get_notices( [
+    'cpt_add_manager_result',
+    'cpt_remove_manager_result'
+  ] );
 
   ob_start();
 

--- a/admin/cpt-client-managers.php
+++ b/admin/cpt-client-managers.php
@@ -5,7 +5,7 @@ use Client_Power_Tools\Core\Common;
 
 function cpt_client_managers() {
 
-  if ( ! current_user_can( 'cpt-manage-settings' ) ) {
+  if ( ! current_user_can( 'cpt-manage-team' ) ) {
     wp_die(
       '<p>' . __( 'Sorry, you are not allowed to access this page.' ) . '</p>',
       403
@@ -112,8 +112,7 @@ function cpt_client_manager_list() {
 
     ?>
 
-      <form id="client-manager-list" method="get">
-        <?php $client_manager_list->views(); ?>
+      <form id="client-manager-list" method="GET">
         <?php $client_manager_list->display() ?>
       </form>
 

--- a/admin/cpt-client-managers.php
+++ b/admin/cpt-client-managers.php
@@ -12,9 +12,23 @@ function cpt_client_managers() {
     );
   }
 
+  if ( isset( $_REQUEST[ 'cpt_action' ] ) && isset( $_REQUEST[ 'user_id' ] ) ) {
+
+    $action_user_id = sanitize_key( intval( $_REQUEST[ 'user_id' ] ) );
+
+    switch ( sanitize_key( $_REQUEST[ 'cpt_action' ] ) ) {
+
+      case 'cpt_remove_client_manager':
+        cpt_remove_client_manager( $action_user_id );
+        break;
+
+    }
+
+  }
+
   Common\cpt_get_notices( [
     'cpt_add_manager_result',
-    'cpt_remove_manager_result'
+    'cpt_remove_manager_result',
   ] );
 
   ob_start();
@@ -274,5 +288,12 @@ function cpt_get_managers_clients( $user_id ) {
 function cpt_remove_client_manager( $user_id ) {
 
   if ( ! $user_id ) { return; }
+
+  $user = new \WP_User( $user_id );
+  $user->remove_role( 'cpt-client-manager' );
+
+  $result = 'Client manager removed.';
+
+  set_transient( 'cpt_remove_manager_result', $result, 45  );
 
 }

--- a/admin/cpt-client-managers.php
+++ b/admin/cpt-client-managers.php
@@ -206,7 +206,7 @@ function cpt_new_client_manager_email( $user_id ) {
   $subject        = 'Your client manager account has been created. Please set your password.';
 
   $activation_key = get_password_reset_key( $user );
-  $activation_url = home_url() . '?cpt_login=setpw&key=' . $activation_key . '&login=' . urlencode( $user->user_login ) . '&redirect=' . esc_url( admin_url( 'admin.php?page=cpt' ) );
+  $activation_url = home_url() . '?cpt_login=setpw&key=' . $activation_key . '&login=' . urlencode( $user->user_login );
 
   ob_start();
 

--- a/admin/cpt-client-managers.php
+++ b/admin/cpt-client-managers.php
@@ -121,3 +121,31 @@ function cpt_client_manager_list() {
   echo ob_get_clean();
 
 }
+
+
+// Returns an array of client user objects.
+function cpt_get_managers_clients( $user_id ) {
+
+  if ( ! $user_id ) { return; }
+
+  $args = [
+    'meta_key'      => 'cpt_client_manager',
+    'meta_value'    => $user_id,
+    'role'          => 'cpt-client',
+    'orderby'       => 'display_name',
+    'order'         => 'ASC',
+  ];
+
+  $client_query  = new \WP_USER_QUERY( $args );
+  $clients       = $client_query->get_results();
+
+  return $clients;
+
+}
+
+
+function cpt_remove_client_manager( $user_id ) {
+
+  if ( ! $user_id ) { return; }
+
+}

--- a/admin/cpt-client-managers.php
+++ b/admin/cpt-client-managers.php
@@ -103,6 +103,26 @@ function cpt_add_client_manager_form() {
 }
 
 
+function cpt_process_new_client_manager() {
+
+  if ( isset( $_POST[ 'cpt_new_client_manager_nonce' ] ) && wp_verify_nonce( $_POST[ 'cpt_new_client_manager_nonce' ], 'cpt_new_client_manager_added' ) ) {
+
+    set_transient( 'cpt_new_client_manager_result', 'Success!', 45  );
+
+    wp_redirect( $_POST[ '_wp_http_referer' ] );
+    exit;
+
+  } else {
+
+    die();
+
+  }
+
+}
+
+add_action( 'admin_post_cpt_new_client_manager_added', __NAMESPACE__ . '\cpt_process_new_client_manager' );
+
+
 function cpt_client_manager_list() {
 
   ob_start();
@@ -139,7 +159,11 @@ function cpt_get_managers_clients( $user_id ) {
   $client_query  = new \WP_USER_QUERY( $args );
   $clients       = $client_query->get_results();
 
-  return $clients;
+  foreach ( $clients as $client ) {
+    $client_data[] = Common\cpt_get_client_data( $client->ID );
+  }
+
+  return $client_data;
 
 }
 

--- a/admin/cpt-client-table.php
+++ b/admin/cpt-client-table.php
@@ -66,7 +66,7 @@ class Client_List_Table extends Includes\WP_List_Table  {
     return sprintf( '<strong>%1$s</strong>%2$s<br />%3$s',
       /* $1%s */ $item[ 'client_name' ],
       /* $2%s */ $item[ 'client_id' ] ? ' <span style="color:silver">(' . $item[ 'client_id' ] . ')</span>' : '',
-      /* $3%s */ $this->row_actions( $actions )
+      /* $3%s */ $this->row_actions( $actions, true )
     );
 
   }

--- a/admin/cpt-client-table.php
+++ b/admin/cpt-client-table.php
@@ -105,9 +105,6 @@ class Client_List_Table extends Includes\WP_List_Table  {
   }
 
 
-
-
-
   /**
   * Get Columns
   *
@@ -188,26 +185,34 @@ class Client_List_Table extends Includes\WP_List_Table  {
 
   function get_views() {
 
-    $statuses = explode( "\n", get_option( 'cpt_client_statuses' ) );
-    $current  = isset( $_REQUEST[ 'client_status' ] ) ? sanitize_text_field( urldecode( $_REQUEST[ 'client_status' ] ) ) : 'all';
-    $views    = array();
+    $params         = explode( "\n", get_option( 'cpt_client_statuses' ) );
+    $current_status = isset( $_REQUEST[ 'client_status' ] ) ? sanitize_text_field( urldecode( $_REQUEST[ 'client_status' ] ) ) : 'all';
+    $curr_mgr       = Common\cpt_get_name( get_current_user_id() );
+    $curr_mgr_param = isset( $_REQUEST[ 'client_manager' ] ) ? sanitize_text_field( urldecode( $_REQUEST[ 'client_manager' ] ) ) : '';
+    $views          = array();
 
-    array_unshift( $statuses, 'All' );
+    array_unshift( $params, 'All', 'Mine' );
 
-    foreach( $statuses as $status ) {
+    foreach( $params as $key => $val ) {
 
-      $class        = '';
-      $status       = trim( $status );
-      $status_param = urlencode( $status );
+      $class          = '';
+      $val            = trim( $val );
+      $status_param   = urlencode( $val );
 
-      if ( $current == $status_param ) {
+      if ( $current_status == $status_param || ( $key == 1 && $curr_mgr_param == $curr_mgr ) ) {
+        $class = ' class="current"';
+      } elseif ( $key == 0 && $current_status == 'all' ) {
         $class = ' class="current"';
       }
 
       if ( $status_param == 'All' ) {
-        $link = '<a href="' . remove_query_arg( 'client_status' ) . '"' . $class . '>' . $status . '</a>';
+        $link = '<a href="' . remove_query_arg( [ 'client_status', 'client_manager' ] ) . '"' . $class . '>' . $val . '</a>';
       } else {
-        $link = '<a href="' . add_query_arg( 'client_status', $status_param ) . '"' . $class . '>' . $status . '</a>';
+        $link = '<a href="' . add_query_arg( 'client_status', $status_param ) . '"' . $class . '>' . $val . '</a>';
+      }
+
+      if ( $status_param == 'Mine' ) {
+        $link = '<a href="' . add_query_arg( 'client_manager', $curr_mgr ) . '"' . $class . '>' . $val . '</a>';
       }
 
       $views[ $status_param ] = $link;
@@ -286,6 +291,20 @@ class Client_List_Table extends Includes\WP_List_Table  {
       foreach( $data as $i => $client ) {
 
         if ( $client[ 'client_status' ] !== $client_status_filter ) {
+          unset( $data[ $i ] );
+        }
+
+      }
+
+    }
+
+    if ( isset( $_REQUEST[ 'client_manager' ] ) ) {
+
+      $client_status_filter = sanitize_text_field( urldecode( $_REQUEST[ 'client_manager' ] ) );
+
+      foreach( $data as $i => $client ) {
+
+        if ( $client[ 'client_manager' ] !== $client_status_filter ) {
           unset( $data[ $i ] );
         }
 

--- a/admin/cpt-client-table.php
+++ b/admin/cpt-client-table.php
@@ -197,25 +197,25 @@ class Client_List_Table extends Includes\WP_List_Table  {
 
       $class          = '';
       $val            = trim( $val );
-      $status_param   = urlencode( $val );
+      $curr_param   = urlencode( $val );
 
-      if ( $current_status == $status_param || ( $key == 1 && $curr_mgr_param == $curr_mgr ) ) {
+      if ( $current_status == $curr_param || ( $key == 1 && $curr_mgr_param == $curr_mgr ) ) {
         $class = ' class="current"';
       } elseif ( $key == 0 && $current_status == 'all' ) {
         $class = ' class="current"';
       }
 
-      if ( $status_param == 'All' ) {
+      if ( $curr_param == 'All' ) {
         $link = '<a href="' . remove_query_arg( [ 'client_status', 'client_manager' ] ) . '"' . $class . '>' . $val . '</a>';
       } else {
-        $link = '<a href="' . add_query_arg( 'client_status', $status_param ) . '"' . $class . '>' . $val . '</a>';
+        $link = '<a href="' . add_query_arg( 'client_status', $curr_param ) . '"' . $class . '>' . $val . '</a>';
       }
 
-      if ( $status_param == 'Mine' ) {
+      if ( $curr_param == 'Mine' ) {
         $link = '<a href="' . add_query_arg( 'client_manager', $curr_mgr ) . '"' . $class . '>' . $val . '</a>';
       }
 
-      $views[ $status_param ] = $link;
+      $views[ $curr_param ] = $link;
 
     }
 

--- a/admin/cpt-client-table.php
+++ b/admin/cpt-client-table.php
@@ -58,16 +58,10 @@ class Client_List_Table extends Includes\WP_List_Table  {
   */
   function column_client_name( $item ) {
 
-    // Build row actions.
-    $actions = [
-      'view_client' => '<a href="' . add_query_arg( 'user_id', $item[ 'ID' ] ) . '">View Client</a>',
-    ];
-
     // Return the contents.
-    return sprintf( '<strong>%1$s</strong>%2$s<br />%3$s',
+    return sprintf( '<strong><a href="' . add_query_arg( 'user_id', $item[ 'ID' ] ) . '">%1$s</a></strong>%2$s',
       /* $1%s */ $item[ 'client_name' ],
       /* $2%s */ $item[ 'client_id' ] ? ' <span style="color:silver">(' . $item[ 'client_id' ] . ')</span>' : '',
-      /* $3%s */ $this->row_actions( $actions, true )
     );
 
   }

--- a/admin/cpt-client-table.php
+++ b/admin/cpt-client-table.php
@@ -7,6 +7,7 @@
 
 namespace Client_Power_Tools\Core\Admin;
 use Client_Power_Tools\Core\Includes;
+use Client_Power_Tools\Core\Common;
 
 class Client_List_Table extends Includes\WP_List_Table  {
 
@@ -73,14 +74,6 @@ class Client_List_Table extends Includes\WP_List_Table  {
 
 
   /**
-  * Client Status Method
-  */
-  function column_client_status( $item ) {
-    return sprintf( $item[ 'client_status' ] );
-  }
-
-
-  /**
   * Client Messages Method
   */
   function column_client_messages( $item ) {
@@ -90,6 +83,29 @@ class Client_List_Table extends Includes\WP_List_Table  {
     }
 
   }
+
+
+  /**
+  * Client Status Method
+  */
+  function column_client_status( $item ) {
+    return sprintf( $item[ 'client_status' ] );
+  }
+
+
+  /**
+  * Client Manager Method
+  */
+  function column_client_manager( $item ) {
+
+    if ( $item[ 'client_manager' ] ) {
+      return sprintf( $item[ 'client_manager' ] );
+    }
+
+  }
+
+
+
 
 
   /**
@@ -106,6 +122,7 @@ class Client_List_Table extends Includes\WP_List_Table  {
       'client_name'     => 'Client',
       'client_messages' => 'Messages',
       'client_status'   => 'Status',
+      'client_manager'  => 'Manager',
     ];
 
     return $columns;
@@ -122,6 +139,7 @@ class Client_List_Table extends Includes\WP_List_Table  {
       'client_name'     => [ 'client_name', true ],
       'client_messages' => [ 'msg_count', false ],
       'client_status'   => [ 'client_status', false ],
+      'client_manager'  => [ 'client_manager', false ],
     ];
 
     return $sortable_columns;
@@ -247,12 +265,13 @@ class Client_List_Table extends Includes\WP_List_Table  {
         $cpt_messages = new \WP_Query( $args );
 
         $data[] = [
-          'ID'            => $client->ID,
-          'client_name'   => $client->display_name,
-          'client_email'  => $client->user_email,
-          'client_id'     => get_user_meta( $client->ID, 'cpt_client_id', true ),
-          'client_status' => get_user_meta( $client->ID, 'cpt_client_status', true ),
-          'msg_count'     => number_format_i18n( $cpt_messages->post_count ),
+          'ID'              => $client->ID,
+          'client_name'     => $client->display_name,
+          'client_email'    => $client->user_email,
+          'client_id'       => get_user_meta( $client->ID, 'cpt_client_id', true ),
+          'client_manager'  => trim( Common\cpt_get_name( get_user_meta( $client->ID, 'cpt_client_manager', true ) ) ),
+          'client_status'   => get_user_meta( $client->ID, 'cpt_client_status', true ),
+          'msg_count'       => number_format_i18n( $cpt_messages->post_count ),
         ];
 
       }

--- a/admin/cpt-client-table.php
+++ b/admin/cpt-client-table.php
@@ -263,12 +263,27 @@ class Client_List_Table extends Includes\WP_List_Table  {
 
         $cpt_messages = new \WP_Query( $args );
 
+        $manager_data = get_userdata( get_user_meta( $client->ID, 'cpt_client_manager', true ) );
+
+        if ( $manager_data ) {
+
+          // Checks for clients whose manager is no longer assigned that role.
+          if ( ! in_array( 'cpt-client-manager', $manager_data->roles ) ) {
+            $manager_name = '<span style="color: silver;">Unassigned</span>';
+          } else {
+            $manager_name = trim( Common\cpt_get_name( $manager_data->ID ) );
+          }
+
+        } else {
+          $manager_name = '<span style="color: silver;">Unassigned</span>';
+        }
+
         $data[] = [
           'ID'              => $client->ID,
           'client_name'     => $client->display_name,
           'client_email'    => $client->user_email,
           'client_id'       => get_user_meta( $client->ID, 'cpt_client_id', true ),
-          'client_manager'  => trim( Common\cpt_get_name( get_user_meta( $client->ID, 'cpt_client_manager', true ) ) ),
+          'client_manager'  => $manager_name,
           'client_status'   => get_user_meta( $client->ID, 'cpt_client_status', true ),
           'msg_count'       => number_format_i18n( $cpt_messages->post_count ),
         ];

--- a/admin/cpt-client-table.php
+++ b/admin/cpt-client-table.php
@@ -197,11 +197,11 @@ class Client_List_Table extends Includes\WP_List_Table  {
 
       $class          = '';
       $val            = trim( $val );
-      $curr_param   = urlencode( $val );
+      $curr_param     = urlencode( $val );
 
       if ( $current_status == $curr_param || ( $key == 1 && $curr_mgr_param == $curr_mgr ) ) {
         $class = ' class="current"';
-      } elseif ( $key == 0 && $current_status == 'all' ) {
+      } elseif ( ! isset( $_REQUEST[ 'client_status' ] ) && ! isset( $_REQUEST[ 'client_manager' ] ) && $key == 0 && $current_status == 'all' ) {
         $class = ' class="current"';
       }
 

--- a/admin/cpt-clients.php
+++ b/admin/cpt-clients.php
@@ -92,15 +92,19 @@ function cpt_clients() {
 
           } else {
 
-            ?>
+            if ( current_user_can( 'cpt-manage-clients' ) ) {
 
-              <button class="button cpt-click-to-expand"><?php _e( 'Add a Client' ); ?></button>
+              ?>
 
-              <div class="cpt-this-expands">
-                <?php cpt_new_client_form(); ?>
-              </div>
+                <button class="button cpt-click-to-expand"><?php _e( 'Add a Client' ); ?></button>
 
-            <?php
+                <div class="cpt-this-expands">
+                  <?php cpt_new_client_form(); ?>
+                </div>
+
+              <?php
+
+            }
 
             cpt_client_list();
 

--- a/admin/cpt-clients.php
+++ b/admin/cpt-clients.php
@@ -31,7 +31,7 @@ function cpt_clients() {
         $page_header .= '<p id="cpt-client-status" class="dashicons-before status-' . strtolower( $client_status ) . '">' . $client_status . '</p>';
       }
 
-      $page_header .= '<h1 id="cpt-page-title">' . Common\cpt_get_client_name( $user_id );
+      $page_header .= '<h1 id="cpt-page-title">' . Common\cpt_get_name( $user_id );
 
         if ( $client_id ) {
           $page_header .= ' <span style="color:silver">(' . $client_id . ')</span>';

--- a/admin/cpt-clients.php
+++ b/admin/cpt-clients.php
@@ -12,10 +12,13 @@ function cpt_clients() {
     );
   }
 
-  Common\cpt_get_notices( 'cpt_new_client_result' );
-  Common\cpt_get_notices( 'cpt_update_client_result' );
-  Common\cpt_get_notices( 'cpt_delete_client_result' );
-  Common\cpt_get_notices( 'cpt_new_message_result' );
+  Common\cpt_get_notices( [
+    'cpt_new_client_result',
+    'cpt_update_client_result',
+    'cpt_update_client_result',
+    'cpt_delete_client_result',
+    'cpt_new_message_result'
+  ] );
 
   ob_start();
 

--- a/admin/cpt-clients.php
+++ b/admin/cpt-clients.php
@@ -12,6 +12,7 @@ function cpt_clients() {
     );
   }
 
+  Common\cpt_get_notices( 'cpt_new_client_result' );
   Common\cpt_get_notices( 'cpt_update_client_result' );
   Common\cpt_get_notices( 'cpt_delete_client_result' );
   Common\cpt_get_notices( 'cpt_new_message_result' );
@@ -87,7 +88,17 @@ function cpt_clients() {
 
           } else {
 
-            cpt_get_client_list();
+            ?>
+
+              <button class="button cpt-click-to-expand"><?php _e( 'Add a Client' ); ?></button>
+
+              <div class="cpt-this-expands">
+                <?php cpt_new_client_form(); ?>
+              </div>
+
+            <?php
+
+            cpt_client_list();
 
           }
 
@@ -112,7 +123,7 @@ function cpt_get_client_profile( $user_id ) {
 }
 
 
-function cpt_get_client_list() {
+function cpt_client_list() {
 
   ob_start();
 

--- a/admin/cpt-clients.php
+++ b/admin/cpt-clients.php
@@ -25,10 +25,9 @@ function cpt_clients() {
       $user_id        = sanitize_key( intval( $_REQUEST[ 'user_id' ] ) );
       $client_data    = Common\cpt_get_client_data( $user_id );
       $client_id      = $client_data[ 'client_id' ];
-      $client_status  = $client_data[ 'status' ];
 
-      if ( $client_status ) {
-        $page_header .= '<p id="cpt-client-status" class="dashicons-before status-' . strtolower( $client_status ) . '">' . $client_status . '</p>';
+      if ( isset( $client_data[ 'status' ] ) ) {
+        $page_header .= '<p id="cpt-client-status">' . $client_data[ 'status' ] . '</p>';
       }
 
       $page_header .= '<h1 id="cpt-page-title">' . Common\cpt_get_name( $user_id );
@@ -38,6 +37,20 @@ function cpt_clients() {
         }
 
       $page_header .= '</h1>';
+
+      if ( isset( $client_data[ 'manager_id' ] ) ) {
+
+        $page_header .= '<p id="cpt-client-manager">';
+
+        if ( get_current_user_id() == $client_data[ 'manager_id' ] ) {
+          $page_header .= 'Your Client';
+        } else {
+          $page_header .= Common\cpt_get_name( $client_data[ 'manager_id' ] ) . '\'s Client';
+        }
+
+        $page_header .= '</p>';
+
+      }
 
     } else {
 

--- a/admin/cpt-clients.php
+++ b/admin/cpt-clients.php
@@ -56,6 +56,7 @@ function cpt_clients() {
     } else {
 
       $page_header .= '<h1 id="cpt-page-title">Clients</h1>';
+      $page_header .= '<p id="cpt-subtitle">Client Power Tools</p>';
 
     }
 
@@ -132,7 +133,7 @@ function cpt_client_list() {
 
     ?>
 
-      <form id="client-list" method="get">
+      <form id="client-list" method="GET">
         <?php $client_list->views(); ?>
         <?php $client_list->display() ?>
       </form>

--- a/admin/cpt-edit-client.php
+++ b/admin/cpt-edit-client.php
@@ -46,7 +46,7 @@ function cpt_edit_client_form( $client_data ) {
                 <label for="first_name">First Name<br /><small>(required)</small></label>
               </th>
               <td>
-                <input name="first_name" id="first_name" class="regular-text" type="text" required aria-required="true" value="<?php echo $client_data[ 'first_name' ]; ?>">
+                <input name="first_name" id="first_name" class="regular-text" type="text" data-required="true" value="<?php echo $client_data[ 'first_name' ]; ?>">
               </td>
             </tr>
             <tr>
@@ -54,7 +54,7 @@ function cpt_edit_client_form( $client_data ) {
                 <label for="last_name">Last Name<br /><small>(required)</small></label>
               </th>
               <td>
-                <input name="last_name" id="last_name" class="regular-text" type="text" required aria-required="true" value="<?php echo $client_data[ 'last_name' ]; ?>">
+                <input name="last_name" id="last_name" class="regular-text" type="text" data-required="true" value="<?php echo $client_data[ 'last_name' ]; ?>">
               </td>
             </tr>
             <tr>
@@ -62,7 +62,7 @@ function cpt_edit_client_form( $client_data ) {
                 <label for="email">Email Address<br /><small>(required)</small></label>
               </th>
               <td>
-                <input name="email" id="email" class="regular-text" type="text" required aria-required="true" autocapitalize="none" autocorrect="off" value="<?php echo $client_data[ 'email' ]; ?>">
+                <input name="email" id="email" class="regular-text" type="text" data-required="true" autocapitalize="none" autocorrect="off" value="<?php echo $client_data[ 'email' ]; ?>">
               </td>
             </tr>
             <tr>

--- a/admin/cpt-edit-client.php
+++ b/admin/cpt-edit-client.php
@@ -75,30 +75,18 @@ function cpt_edit_client_form( $client_data ) {
             </tr>
             <tr>
               <th scope="row">
+                <label for="client_manager">Client Manager</label>
+              </th>
+              <td>
+                <?php echo cpt_get_client_manager_select( '', $client_data[ 'manager_id' ] ); ?>
+              </td>
+            </tr>
+            <tr>
+              <th scope="row">
                 <label for="client_status">Client Status</label>
               </th>
               <td>
-                <select name="client_status" id="client_status">
-
-                  <?php
-
-                    $statuses = $statuses_array = explode( "\n", get_option( 'cpt_client_statuses' ) );
-
-                    foreach ( $statuses as $status ) {
-
-                      if ( $status == $client_data[ 'status' ] ) {
-                        echo '<option selected>';
-                      } else {
-                        echo '<option>';
-                      }
-
-                      echo $status . '</option>';
-
-                    }
-
-                  ?>
-
-                </select>
+                <?php echo cpt_get_client_statuses_select( '', $client_data[ 'status' ] ); ?>
               </td>
             </tr>
           </tbody>
@@ -140,9 +128,11 @@ function cpt_process_client_update() {
     } else {
 
       $client_id      = sanitize_text_field( $_POST[ 'client_id' ] );
+      $client_manager = sanitize_text_field( $_POST[ 'client_manager' ] );
       $client_status  = sanitize_text_field( $_POST[ 'client_status' ] );
 
       update_user_meta( $user_id, 'cpt_client_id', $client_id );
+      update_user_meta( $user_id, 'cpt_client_manager', $client_manager );
       update_user_meta( $user_id, 'cpt_client_status', $client_status );
 
       $result = 'Client updated.';

--- a/admin/cpt-edit-client.php
+++ b/admin/cpt-edit-client.php
@@ -8,7 +8,7 @@ function cpt_edit_client( $user_id ) {
   if ( ! $user_id || ! is_user_logged_in() ) { return; }
 
   $client_data  = Common\cpt_get_client_data( $user_id );
-  $client_name  = Common\cpt_get_client_name( $user_id );
+  $client_name  = Common\cpt_get_name( $user_id );
 
   if ( is_admin() && current_user_can( 'cpt-manage-clients' ) ) {
 
@@ -189,7 +189,7 @@ function cpt_delete_client_button( $user_id ) {
 
   if ( ! $user_id ) { return; }
 
-  $client_name  = Common\cpt_get_client_name( $user_id );
+  $client_name  = Common\cpt_get_name( $user_id );
   $button_txt   = __( 'Delete' ) . ' ' . $client_name;
 
   ob_start();
@@ -217,7 +217,7 @@ function cpt_process_delete_client() {
   if ( isset( $_POST[ 'cpt_client_deleted_nonce' ] ) && wp_verify_nonce( $_POST[ 'cpt_client_deleted_nonce' ], 'cpt_client_deleted' ) ) {
 
     $user_id      = sanitize_key( intval( $_POST[ 'clients_user_id' ] ) );
-    $client_name  = Common\cpt_get_client_name( $user_id );
+    $client_name  = Common\cpt_get_name( $user_id );
 
     $args = [
       'fields'          => 'ids',

--- a/admin/cpt-new-client.php
+++ b/admin/cpt-new-client.php
@@ -3,48 +3,13 @@
 namespace Client_Power_Tools\Core\Admin;
 use Client_Power_Tools\Core\Common;
 
-function cpt_new_client() {
-
-  if ( ! current_user_can( 'cpt-manage-clients' ) ) {
-    wp_die(
-      '<p>' . __( 'Sorry, you are not allowed to access this page.' ) . '</p>',
-      403
-    );
-  }
-
-  cpt_get_admin_notices( 'cpt_new_client_result' );
-
-  ob_start();
-
-    ?>
-
-      <div id="cpt-admin" class="wrap">
-
-        <div id="cpt-admin-header">
-          <img src="<?php echo CLIENT_POWER_TOOLS_DIR_URL; ?>admin/images/cpt-logo.svg" height="auto" width="100%" />
-          <div id="cpt-admin-page-title">
-            <h1 id="cpt-page-title">Add Client</h1>
-            <p id="cpt-subtitle">Client Power Tools</p>
-          </div>
-        </div>
-        <hr class="wp-header-end">
-
-        <?php cpt_new_client_form(); ?>
-
-      </div>
-
-    <?php
-
-  echo ob_get_clean();
-
-}
-
-
 function cpt_new_client_form() {
 
   ob_start();
 
     ?>
+
+      <h3><?php _e( 'Add a Client' ); ?></h3>
 
       <form action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" method="POST">
 

--- a/admin/cpt-new-client.php
+++ b/admin/cpt-new-client.php
@@ -105,7 +105,7 @@ function cpt_new_client_form() {
         </table>
 
         <p class="submit">
-          <input name="submit" id="submit" class="button button-primary" type="submit" value="Create Client">
+          <input name="submit" id="submit" class="button button-primary" type="submit" value="<?php _e( 'Add Client' ); ?>">
         </p>
 
       </form>

--- a/admin/cpt-new-client.php
+++ b/admin/cpt-new-client.php
@@ -171,13 +171,14 @@ function cpt_process_new_client() {
     } else {
 
       update_user_meta( $new_client, 'cpt_client_id', sanitize_text_field( $_POST[ 'client_id' ] ) );
+      update_user_meta( $new_client, 'cpt_client_manager', sanitize_text_field( $_POST[ 'client_manager' ] ) );
       update_user_meta( $new_client, 'cpt_client_status', sanitize_text_field( $_POST[ 'client_status' ] ) );
 
       if ( ! $existing_client_id ) { cpt_new_client_email( $new_client ); }
 
       $client_profile_url = Common\cpt_get_client_profile_url( $new_client );
 
-      $result = 'Client created. <a href="' . $client_profile_url . '">View ' . Common\cpt_get_client_name( $new_client ) . '\'s profile</a>.';
+      $result = 'Client created. <a href="' . $client_profile_url . '">View ' . Common\cpt_get_name( $new_client ) . '\'s profile</a>.';
 
     }
 
@@ -197,14 +198,15 @@ function cpt_process_new_client() {
 add_action( 'admin_post_cpt_new_client_added', __NAMESPACE__ . '\cpt_process_new_client' );
 
 
-function cpt_new_client_email( $user_id ) {
+function cpt_new_client_email( $clients_user_id ) {
 
-  if ( ! $user_id ) { return; }
+  if ( ! $clients_user_id ) { return; }
 
-  $user           = get_userdata( $user_id );
+  $user           = get_userdata( $clients_user_id );
+  $client_data    = Common\cpt_get_client_data( $clients_user_id );
 
-  $from_name      = get_option( 'cpt_new_client_email_from_name' );
-  $from_email     = get_option( 'cpt_new_client_email_from_email' );
+  $from_name      = Common\cpt_get_name( $client_data[ 'manager_id' ] );
+  $from_email     = $client_data[ 'manager_email' ];
 
   $headers[]      = 'Content-Type: text/html; charset=UTF-8';
   $headers[]      = $from_name ? 'From: ' . $from_name . ' <' . $from_email . '>' : 'From: ' . $from_email;

--- a/admin/cpt-new-client.php
+++ b/admin/cpt-new-client.php
@@ -87,10 +87,18 @@ function cpt_new_client_form() {
             </tr>
             <tr>
               <th scope="row">
+                <label for="client_manager">Client Manager</label>
+              </th>
+              <td>
+                <?php echo cpt_get_client_manager_select() ?>
+              </td>
+            </tr>
+            <tr>
+              <th scope="row">
                 <label for="client_status">Client Status</label>
               </th>
               <td>
-                <?php echo cpt_get_client_statuses_select( 'client_status' ) ?>
+                <?php echo cpt_get_client_statuses_select() ?>
               </td>
             </tr>
           </tbody>

--- a/admin/cpt-settings.php
+++ b/admin/cpt-settings.php
@@ -213,7 +213,7 @@ function cpt_client_managers() {
                     <label for="first_name">First Name<br /><small>(required)</small></label>
                   </th>
                   <td>
-                    <input name="first_name" id="first_name" class="regular-text" type="text" required aria-required="true">
+                    <input name="first_name" id="first_name" class="regular-text" type="text" data-required="true">
                   </td>
                 </tr>
                 <tr>
@@ -229,7 +229,7 @@ function cpt_client_managers() {
                     <label for="email">Email Address<br /><small>(required)</small></label>
                   </th>
                   <td>
-                    <input name="email" id="email" class="regular-text" type="text" required aria-required="true" autocapitalize="none" autocorrect="off">
+                    <input name="email" id="email" class="regular-text" type="text" data-required="true" autocapitalize="none" autocorrect="off">
                   </td>
               </tbody>
             </table>
@@ -241,6 +241,10 @@ function cpt_client_managers() {
           </form>
 
         </div>
+
+        <p></p>
+        <button class="button cpt-click-to-expand">Click to Expand</button>
+        <div class="cpt-this-expands"><h3>Hello world!</h3></div>
 
       <?php
 

--- a/admin/cpt-settings.php
+++ b/admin/cpt-settings.php
@@ -40,8 +40,6 @@ function cpt_settings() {
           <?php submit_button( 'Save Settings' ); ?>
         </form>
 
-        <!-- Insert selector for frontend client dashboard page. -->
-
       </div>
 
     <?php
@@ -155,99 +153,6 @@ add_action( 'admin_init', __NAMESPACE__ . '\cpt_client_managers_settings_init' )
 
 function cpt_client_managers_section() {
   echo '<p>' . __( 'Client managers can be assigned to individual clients.' ) . '</p>';
-}
-
-
-function cpt_client_managers() {
-
-  $args = [
-    'role__in'  => [ 'administrator', 'cpt-client-manager' ],
-    'orderby'   => 'display_name',
-    'order'     => 'ASC',
-  ];
-
-  $client_managers_query  = new \WP_USER_QUERY( $args );
-  $client_managers        = $client_managers_query->get_results();
-
-  if ( ! empty( $client_managers ) ) {
-
-    echo '<ul id="client-managers">';
-
-      foreach ( $client_managers as $client_manager ) {
-
-        echo '<li>';
-
-          echo $client_manager->display_name;
-
-          if ( in_array( 'administrator', $client_manager->roles ) ) {
-            echo ' <span style="color: silver;">(admin)</span>';
-          }
-
-        echo '</li>';
-
-      }
-
-    echo '</ul>';
-
-    echo '<button class="button cpt-click-to-expand">' . __( 'Add a Client Manager' ) . '</button>';
-
-    ob_start();
-
-      ?>
-
-        <div class="cpt-this-expands">
-
-          <h4>Add a Client Manager</h4>
-
-          <p><?php _e( 'Assign the client manager role to a new or existing user. Add the first and last name as you want clients to see them.' ); ?></p>
-
-          <form action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" method="POST">
-
-            <?php wp_nonce_field( 'cpt_new_client_manager_added', 'cpt_new_client_manager_nonce' ); ?>
-            <input name="action" value="cpt_new_client_manager_added" type="hidden">
-
-            <table class="form-table" role="presentation">
-              <tbody>
-                <tr>
-                  <th scope="row">
-                    <label for="first_name">First Name<br /><small>(required)</small></label>
-                  </th>
-                  <td>
-                    <input name="first_name" id="first_name" class="regular-text" type="text" data-required="true">
-                  </td>
-                </tr>
-                <tr>
-                  <th scope="row">
-                    <label for="last_name">Last Name<br /><small>(required)</small></label>
-                  </th>
-                  <td>
-                    <input name="last_name" id="last_name" class="regular-text" type="text" data-required="true">
-                  </td>
-                </tr>
-                <tr>
-                  <th scope="row">
-                    <label for="email">Email Address<br /><small>(required)</small></label>
-                  </th>
-                  <td>
-                    <input name="email" id="email" class="regular-text" type="text" data-required="true" autocapitalize="none" autocorrect="off">
-                  </td>
-              </tbody>
-            </table>
-
-            <p class="submit">
-              <input name="submit" id="submit" class="button button-primary" type="submit" value="Add Client Manager">
-            </p>
-
-          </form>
-
-        </div>
-
-      <?php
-
-    echo ob_get_clean();
-
-  }
-
 }
 
 

--- a/admin/cpt-settings.php
+++ b/admin/cpt-settings.php
@@ -238,7 +238,7 @@ function cpt_status_update_request_button_settings_init() {
   // Status Update Request Notification Email
   add_settings_field(
     'cpt_status_update_req_notice_email',
-    '<label for="cpt_status_update_req_notice_email">Status Update Request Notification Email<br /><small>(required)</small></label>',
+    '<label for="cpt_status_update_req_notice_email">Additional Status Update Request Notification Email<br /><small>(optional)</small></label>',
     __NAMESPACE__ . '\cpt_status_update_req_notice_email',
     'cpt-settings',
     'cpt_status_update_request_button_settings',
@@ -281,8 +281,8 @@ function cpt_status_update_req_freq() {
 }
 
 function cpt_status_update_req_notice_email() {
-  echo '<input name="cpt_status_update_req_notice_email" class="regular-text" type="email" required aria-required="true" value="' . get_option( 'cpt_status_update_req_notice_email' ) . '">';
-  echo '<p class="description">' . __( 'When a client requests a status update, the notification will go to this email address.' ) . '</p>';
+  echo '<input name="cpt_status_update_req_notice_email" class="regular-text" type="email" value="' . get_option( 'cpt_status_update_req_notice_email' ) . '">';
+  echo '<p class="description">' . __( 'This address will be CC\'d when a client requests a status update.' ) . '</p>';
 }
 
 

--- a/admin/cpt-settings.php
+++ b/admin/cpt-settings.php
@@ -255,6 +255,26 @@ function cpt_client_managers() {
 }
 
 
+function cpt_process_new_client_manager() {
+
+  if ( isset( $_POST[ 'cpt_new_client_manager_nonce' ] ) && wp_verify_nonce( $_POST[ 'cpt_new_client_manager_nonce' ], 'cpt_new_client_manager_added' ) ) {
+
+    set_transient( 'cpt_new_client_manager_result', 'Success!', 45  );
+
+    wp_redirect( $_POST[ '_wp_http_referer' ] );
+    exit;
+
+  } else {
+
+    die();
+
+  }
+
+}
+
+add_action( 'admin_post_cpt_new_client_manager_added', __NAMESPACE__ . '\cpt_process_new_client_manager' );
+
+
 function cpt_default_client_manager() {
   echo cpt_get_client_manager_select( 'cpt_default_client_manager', get_option( 'cpt_default_client_manager' ) );
 }

--- a/admin/cpt-settings.php
+++ b/admin/cpt-settings.php
@@ -347,28 +347,6 @@ function cpt_new_client_email_settings_init() {
     'cpt-settings',
   );
 
-  // From Name
-  add_settings_field(
-    'cpt_new_client_email_from_name',
-    '<label for="cpt_new_client_email_from_name">From Name<br /><small>(optional)</small></label>',
-    __NAMESPACE__ . '\cpt_new_client_email_from_name',
-    'cpt-settings',
-    'cpt-new-client-email-settings',
-  );
-
-  register_setting( 'cpt-settings', 'cpt_new_client_email_from_name', 'sanitize_text_field' );
-
-  // From Email
-  add_settings_field(
-    'cpt_new_client_email_from_email',
-    '<label for="cpt_new_client_email_from_email">From Email<br /><small>(required)</small></label>',
-    __NAMESPACE__ . '\cpt_new_client_email_from_email',
-    'cpt-settings',
-    'cpt-new-client-email-settings',
-  );
-
-  register_setting( 'cpt-settings', 'cpt_new_client_email_from_email', 'sanitize_email' );
-
   // Subject Line
   add_settings_field(
     'cpt_new_client_email_subject_line',
@@ -397,15 +375,7 @@ add_action( 'admin_init', __NAMESPACE__ . '\cpt_new_client_email_settings_init' 
 
 
 function cpt_new_client_email_section() {
-  echo '<p>' . __( 'When you add a new client, they will receive an email notification with an account activation link.' ) . '</p>';
-}
-
-function cpt_new_client_email_from_name() {
-  echo '<input name="cpt_new_client_email_from_name" class="regular-text" type="text" value="' . get_option( 'cpt_new_client_email_from_name' ) . '">';
-}
-
-function cpt_new_client_email_from_email() {
-  echo '<input name="cpt_new_client_email_from_email" class="regular-text" type="email" required aria-required="true" value="' . get_option( 'cpt_new_client_email_from_email' ) . '">';
+  echo '<p>' . __( 'When you add a new client, they will receive an email notification from their client manager with an account activation link. If you like, you can customize the subject line or add a message to the body of the email.' ) . '</p>';
 }
 
 function cpt_new_client_email_subject_line() {

--- a/admin/cpt-settings.php
+++ b/admin/cpt-settings.php
@@ -132,6 +132,16 @@ function cpt_client_profile_settings_init() {
   );
 
   add_settings_field(
+    'cpt_default_client_manager',
+    '<label for="cpt_default_client_manager">Default Client Manager</label>',
+    __NAMESPACE__ . '\cpt_default_client_manager',
+    'cpt-settings',
+    'cpt-client-profile-settings',
+  );
+
+  register_setting( 'cpt-settings', 'cpt_default_client_manager' );
+
+  add_settings_field(
     'cpt_client_statuses',
     '<label for="cpt_client_statuses">Statuses</label>',
     __NAMESPACE__ . '\cpt_client_statuses',
@@ -157,6 +167,11 @@ add_action( 'admin_init', __NAMESPACE__ . '\cpt_client_profile_settings_init' );
 
 
 function cpt_client_profile_section() {}
+
+
+function cpt_default_client_manager() {
+  echo cpt_get_client_manager_select( 'cpt_default_client_manager', get_option( 'cpt_default_client_manager' ) );
+}
 
 
 function cpt_client_statuses() {

--- a/admin/cpt-settings.php
+++ b/admin/cpt-settings.php
@@ -120,33 +120,101 @@ function cpt_client_dashboard_page_selection() {
 
 }
 
-
-// Client Profile
-function cpt_client_profile_settings_init() {
+// Client Managers
+function cpt_client_managers_settings_init() {
 
   add_settings_section(
-    'cpt-client-profile-settings',
-    'Client Profile',
-    __NAMESPACE__ . '\cpt_client_profile_section',
+    'cpt-client-managers-settings',
+    'Client Managers',
+    __NAMESPACE__ . '\cpt_client_managers_section',
     'cpt-settings',
   );
+
+  add_settings_field(
+    'cpt_client_managers',
+    '<label for="cpt_client_managers">Client Managers</label>',
+    __NAMESPACE__ . '\cpt_client_managers',
+    'cpt-settings',
+    'cpt-client-managers-settings',
+  );
+  // The client managers list isn't an actual setting, so there's no need to use register_setting.
 
   add_settings_field(
     'cpt_default_client_manager',
     '<label for="cpt_default_client_manager">Default Client Manager</label>',
     __NAMESPACE__ . '\cpt_default_client_manager',
     'cpt-settings',
-    'cpt-client-profile-settings',
+    'cpt-client-managers-settings',
   );
 
   register_setting( 'cpt-settings', 'cpt_default_client_manager' );
+
+}
+
+add_action( 'admin_init', __NAMESPACE__ . '\cpt_client_managers_settings_init' );
+
+function cpt_client_managers_section() {
+  echo '<p>' . __( 'Client managers can be assigned to individual clients.' ) . '</p>';
+}
+
+
+function cpt_client_managers() {
+
+  $args = [
+    'role__in'  => [ 'administrator', 'cpt-client-manager' ],
+    'orderby'   => 'display_name',
+    'order'     => 'ASC',
+  ];
+
+  $client_managers_query  = new \WP_USER_QUERY( $args );
+  $client_managers        = $client_managers_query->get_results();
+
+  if ( ! empty( $client_managers ) ) {
+
+    echo '<ul id="client-managers">';
+
+      foreach ( $client_managers as $client_manager ) {
+
+        echo '<li>';
+
+          echo $client_manager->display_name;
+
+          if ( in_array( 'administrator', $client_manager->roles ) ) {
+            echo ' <span style="color: silver;">(admin)</span>';
+          }
+
+        echo '</li>';
+
+      }
+
+    echo '</ul>';
+
+  }
+
+}
+
+
+function cpt_default_client_manager() {
+  echo cpt_get_client_manager_select( 'cpt_default_client_manager', get_option( 'cpt_default_client_manager' ) );
+}
+
+
+// Client Statuses
+function cpt_client_status_settings_init() {
+
+  add_settings_section(
+    'cpt-client-status-settings',
+    'Client Statuses',
+    __NAMESPACE__ . '\cpt_client_status_section',
+    'cpt-settings',
+  );
 
   add_settings_field(
     'cpt_client_statuses',
     '<label for="cpt_client_statuses">Statuses</label>',
     __NAMESPACE__ . '\cpt_client_statuses',
     'cpt-settings',
-    'cpt-client-profile-settings',
+    'cpt-client-status-settings',
   );
 
   register_setting( 'cpt-settings', 'cpt_client_statuses' );
@@ -156,22 +224,17 @@ function cpt_client_profile_settings_init() {
     '<label for="cpt_default_client_status">Default Status</label>',
     __NAMESPACE__ . '\cpt_default_client_status',
     'cpt-settings',
-    'cpt-client-profile-settings',
+    'cpt-client-status-settings',
   );
 
   register_setting( 'cpt-settings', 'cpt_default_client_status' );
 
 }
 
-add_action( 'admin_init', __NAMESPACE__ . '\cpt_client_profile_settings_init' );
+add_action( 'admin_init', __NAMESPACE__ . '\cpt_client_status_settings_init' );
 
 
-function cpt_client_profile_section() {}
-
-
-function cpt_default_client_manager() {
-  echo cpt_get_client_manager_select( 'cpt_default_client_manager', get_option( 'cpt_default_client_manager' ) );
-}
+function cpt_client_status_section() {}
 
 
 function cpt_client_statuses() {

--- a/admin/cpt-settings.php
+++ b/admin/cpt-settings.php
@@ -129,15 +129,6 @@ function cpt_client_managers_settings_init() {
   );
 
   add_settings_field(
-    'cpt_client_managers',
-    '<label for="cpt_client_managers">Client Managers</label>',
-    __NAMESPACE__ . '\cpt_client_managers',
-    'cpt-settings',
-    'cpt-client-managers-settings',
-  );
-  // The client managers list isn't an actual setting, so there's no need to use register_setting.
-
-  add_settings_field(
     'cpt_default_client_manager',
     '<label for="cpt_default_client_manager">Default Client Manager</label>',
     __NAMESPACE__ . '\cpt_default_client_manager',
@@ -151,29 +142,9 @@ function cpt_client_managers_settings_init() {
 
 add_action( 'admin_init', __NAMESPACE__ . '\cpt_client_managers_settings_init' );
 
+
 function cpt_client_managers_section() {
-  echo '<p>' . __( 'Client managers can be assigned to individual clients.' ) . '</p>';
 }
-
-
-function cpt_process_new_client_manager() {
-
-  if ( isset( $_POST[ 'cpt_new_client_manager_nonce' ] ) && wp_verify_nonce( $_POST[ 'cpt_new_client_manager_nonce' ], 'cpt_new_client_manager_added' ) ) {
-
-    set_transient( 'cpt_new_client_manager_result', 'Success!', 45  );
-
-    wp_redirect( $_POST[ '_wp_http_referer' ] );
-    exit;
-
-  } else {
-
-    die();
-
-  }
-
-}
-
-add_action( 'admin_post_cpt_new_client_manager_added', __NAMESPACE__ . '\cpt_process_new_client_manager' );
 
 
 function cpt_default_client_manager() {

--- a/admin/cpt-settings.php
+++ b/admin/cpt-settings.php
@@ -242,10 +242,6 @@ function cpt_client_managers() {
 
         </div>
 
-        <p></p>
-        <button class="button cpt-click-to-expand">Click to Expand</button>
-        <div class="cpt-this-expands"><h3>Hello world!</h3></div>
-
       <?php
 
     echo ob_get_clean();

--- a/admin/cpt-settings.php
+++ b/admin/cpt-settings.php
@@ -189,6 +189,63 @@ function cpt_client_managers() {
 
     echo '</ul>';
 
+    echo '<button class="button cpt-click-to-expand">' . __( 'Add a Client Manager' ) . '</button>';
+
+    ob_start();
+
+      ?>
+
+        <div class="cpt-this-expands">
+
+          <h4>Add a Client Manager</h4>
+
+          <p><?php _e( 'Assign the client manager role to a new or existing user. Add the first and last name as you want clients to see them.' ); ?></p>
+
+          <form action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" method="POST">
+
+            <?php wp_nonce_field( 'cpt_new_client_manager_added', 'cpt_new_client_manager_nonce' ); ?>
+            <input name="action" value="cpt_new_client_manager_added" type="hidden">
+
+            <table class="form-table" role="presentation">
+              <tbody>
+                <tr>
+                  <th scope="row">
+                    <label for="first_name">First Name<br /><small>(required)</small></label>
+                  </th>
+                  <td>
+                    <input name="first_name" id="first_name" class="regular-text" type="text" required aria-required="true">
+                  </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    <label for="last_name">Last Name<br /><small>(required)</small></label>
+                  </th>
+                  <td>
+                    <input name="last_name" id="last_name" class="regular-text" type="text" data-required="true">
+                  </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    <label for="email">Email Address<br /><small>(required)</small></label>
+                  </th>
+                  <td>
+                    <input name="email" id="email" class="regular-text" type="text" required aria-required="true" autocapitalize="none" autocorrect="off">
+                  </td>
+              </tbody>
+            </table>
+
+            <p class="submit">
+              <input name="submit" id="submit" class="button button-primary" type="submit" value="Add Client Manager">
+            </p>
+
+          </form>
+
+        </div>
+
+      <?php
+
+    echo ob_get_clean();
+
   }
 
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,7 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - New client emails will now come from the client manager instead of a default name and email address.
 - Expander script is now more sophisticated. It can handle multiple expanders on the same page, and form elements with data-required="true" will have the required attributes removed when hidden.
 - Add-client form moved to the Clients setting page.
+- Make cpt_get_notices() easier to use by changing the argument to an array so it only needs to be called once.
 
 #### Fixed
 - The standard login form no longer redirects to a blank page when a redirect is present.

--- a/changelog.txt
+++ b/changelog.txt
@@ -8,7 +8,7 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - Prepare the plugin for internationalization.
 
 
-### 1.3.0
+### 1.3
 
 #### Added
 - Client managers can now be added and removed from the new **Managers** submenu, and are also shown in the client list and client profile. As you can when adding a client, you can add a new or existing WordPress user.
@@ -32,7 +32,7 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - Adding an existing user as a client now works as it should.
 
 
-### 1.2.0 - 2020-10-23
+### 1.2 - 2020-10-23
 
 #### Added
 - Setting to disable the status request button entirely.
@@ -43,7 +43,7 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - Creating a new client with an existing user's email address now adds the Client role to the existing user instead of returning an error.
 
 
-### 1.1.0 - 2020-10-20
+### 1.1 - 2020-10-20
 
 #### Added
 - Delete a client from the client's profile page, under **Edit Client**.
@@ -90,7 +90,7 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - Fixed set/change password key sanitization.
 
 
-### 1.0.0 - 2020-10-02
+### 1.0 - 2020-10-02
 
 #### Added
 - Added some frontend form styles for greater compatibility with different themes.
@@ -101,7 +101,7 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - Data sanitization and validation.
 
 
-### 0.1.0 (Beta) - 2020-09-23
+### 0.1 (Beta) - 2020-09-23
 
 #### Added
 - Everything.

--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - Assign a client manager to each client and set a default client manager.
 - Show client manager on client profile and client dashboard.
 - Client manager setting page with add-client manager form.
+- Filter the Clients list by clients assigned to you ("Mine").
 
 #### Changed
 - Messages and status update requests now go to the client manager. (The email will be CC'd to the now-optional status update request notification email address, if you have set one.)

--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 
 #### Added
 - Assign a client manager to each client and set a default client manager.
+- Show client manager on client profile and client dashboard.
 
 #### Changed
 - Messages and status update requests now go to the client manager. (The email will be CC'd to the now-optional status update request notification email address, if you have set one.)

--- a/changelog.txt
+++ b/changelog.txt
@@ -11,10 +11,12 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 ### 1.3.0
 
 #### Added
-- Assign a client manager to each client, and set a default client manager.
+- Assign a client manager to each client and set a default client manager.
 
 #### Changed
 - Messages and status update requests now go to the client manager. (The email will be CC'd to the now-optional status update request notification email address, if you have set one.)
+- New client emails will now come from the client manager instead of a default name and email address.
+
 
 ### 1.2.1 - 2020-10-24
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 #### Changed
 - Messages and status update requests now go to the client manager. (The email will be CC'd to the now-optional status update request notification email address, if you have set one.)
 - New client emails will now come from the client manager instead of a default name and email address.
+- Expander script is now more sophisticated. It can handle multiple expanders on the same page, and form elements with data-required="true" will have the required attributes removed when hidden.
 
 #### Fixed
 - The standard login form no longer redirects to a blank page when a redirect is present.

--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,9 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - Messages and status update requests now go to the client manager. (The email will be CC'd to the now-optional status update request notification email address, if you have set one.)
 - New client emails will now come from the client manager instead of a default name and email address.
 
+#### Fixed
+- The standard login form no longer redirects to a blank page when a redirect is present.
+
 
 ### 1.2.1 - 2020-10-24
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,12 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - Prepare the plugin for internationalization.
 
 
+### 1.3.0
+
+#### Added
+
+
+
 ### 1.2.1 - 2020-10-24
 
 #### Fixed

--- a/changelog.txt
+++ b/changelog.txt
@@ -11,8 +11,10 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 ### 1.3.0
 
 #### Added
+- Assign a client manager to each client, and set a default client manager.
 
-
+#### Changed
+- Messages and status update requests now go to the client manager. (The email will be CC'd to the now-optional status update request notification email address, if you have set one.)
 
 ### 1.2.1 - 2020-10-24
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -11,17 +11,15 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 ### 1.3.0
 
 #### Added
-- Assign a client manager to each client and set a default client manager.
-- Show client manager on client profile and client dashboard.
-- Client manager setting page with add-client manager form.
-- Filter the Clients list by clients assigned to you ("Mine").
-- Client manager role can be removed.
+- Client managers can now be added and removed from the new **Managers** submenu, and are also shown in the client list and client profile. As you can when adding a client, you can add a new or existing WordPress user.
+- Assign a default client manager in the settings.
+- Filter the client list by clients assigned to you ("Mine").
 
 #### Changed
+- The add-client form is now on the Clients page.
 - Messages and status update requests now go to the client manager. (The email will be CC'd to the now-optional status update request notification email address, if you have set one.)
 - New client emails will now come from the client manager instead of a default name and email address.
-- Expander script is now more sophisticated. It can handle multiple expanders on the same page, and form elements with data-required="true" will have the required attributes removed when hidden.
-- Add-client form moved to the Clients setting page.
+- Update the element expander script so it can handle multiple expanders on the same page. Also, form elements within an expander with data-required="true" will have the required attributes removed when hidden.
 - Make cpt_get_notices() easier to use by changing the argument to an array so it only needs to be called once.
 
 #### Fixed

--- a/changelog.txt
+++ b/changelog.txt
@@ -13,11 +13,13 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 #### Added
 - Assign a client manager to each client and set a default client manager.
 - Show client manager on client profile and client dashboard.
+- Client manager setting page with add-client manager form.
 
 #### Changed
 - Messages and status update requests now go to the client manager. (The email will be CC'd to the now-optional status update request notification email address, if you have set one.)
 - New client emails will now come from the client manager instead of a default name and email address.
 - Expander script is now more sophisticated. It can handle multiple expanders on the same page, and form elements with data-required="true" will have the required attributes removed when hidden.
+- Add-client form moved to the Clients setting page.
 
 #### Fixed
 - The standard login form no longer redirects to a blank page when a redirect is present.

--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@ is based on [Keep a Changelog](https://keepachangelog.com).
 - Show client manager on client profile and client dashboard.
 - Client manager setting page with add-client manager form.
 - Filter the Clients list by clients assigned to you ("Mine").
+- Client manager role can be removed.
 
 #### Changed
 - Messages and status update requests now go to the client manager. (The email will be CC'd to the now-optional status update request notification email address, if you have set one.)

--- a/client-power-tools.php
+++ b/client-power-tools.php
@@ -147,7 +147,7 @@ function cpt_activate() {
 		'cpt_default_client_status'						=> 'Active',
 		'cpt_show_status_update_req_button'		=> true,
 		'cpt_status_update_req_freq'					=> 30,
-		'cpt_status_update_req_notice_email'	=> get_bloginfo( 'admin_email' ),
+		'cpt_status_update_req_notice_email'	=> null,
 		'cpt_send_message_content'						=> false,
     'cpt_new_client_email_from_name'     	=> '',
     'cpt_new_client_email_from_email'    	=> get_bloginfo( 'admin_email' ),

--- a/client-power-tools.php
+++ b/client-power-tools.php
@@ -80,6 +80,8 @@ if ( is_admin() ) {
 	require_once( CLIENT_POWER_TOOLS_DIR_PATH . 'admin/cpt-clients.php' );
 	require_once( CLIENT_POWER_TOOLS_DIR_PATH . 'admin/cpt-client-table.php' );
 	require_once( CLIENT_POWER_TOOLS_DIR_PATH . 'admin/cpt-edit-client.php' );
+	require_once( CLIENT_POWER_TOOLS_DIR_PATH . 'admin/cpt-client-managers.php' );
+	require_once( CLIENT_POWER_TOOLS_DIR_PATH . 'admin/cpt-client-manager-table.php' );
 	require_once( CLIENT_POWER_TOOLS_DIR_PATH . 'admin/cpt-settings.php' );
 
 }

--- a/client-power-tools.php
+++ b/client-power-tools.php
@@ -138,8 +138,12 @@ function cpt_activate() {
 	/*
 	* Checks for default options and adds them if necessary.
 	*/
+
+	$admin = get_user_by_email( get_bloginfo( 'admin_email' ) );
+
 	$defaults = [
 		'cpt_client_statuses'									=> 'Active' . "\n" . 'Potential' . "\n" . 'Inactive',
+		'cpt_default_client_manager'					=> $admin->ID,
 		'cpt_default_client_status'						=> 'Active',
 		'cpt_show_status_update_req_button'		=> true,
 		'cpt_status_update_req_freq'					=> 30,

--- a/client-power-tools.php
+++ b/client-power-tools.php
@@ -5,7 +5,7 @@ Plugin Name: Client Power Tools
 Plugin URI: https://clientpowertools.com
 Description: Client Power Tools is an easy-to-use private client dashboard and communication portal built for independent contractors, consultants, lawyers, and other professionals.
 Author: Sam Glover
-Version: 1.2.1
+Version: 1.3
 Author URI: https://samglover.net
 */
 
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 /**
 * Constants
 */
-define( 'CLIENT_POWER_TOOLS_PLUGIN_VERSION', '1.2.1' );
+define( 'CLIENT_POWER_TOOLS_PLUGIN_VERSION', '1.3' );
 define( 'CLIENT_POWER_TOOLS_DIR_PATH', plugin_dir_path( __FILE__ ) );
 define( 'CLIENT_POWER_TOOLS_DIR_URL', plugin_dir_url( __FILE__ ) );
 

--- a/client-power-tools.php
+++ b/client-power-tools.php
@@ -151,8 +151,6 @@ function cpt_activate() {
 		'cpt_status_update_req_freq'					=> 30,
 		'cpt_status_update_req_notice_email'	=> null,
 		'cpt_send_message_content'						=> false,
-    'cpt_new_client_email_from_name'     	=> '',
-    'cpt_new_client_email_from_email'    	=> get_bloginfo( 'admin_email' ),
     'cpt_new_client_email_subject_line'  	=> 'Your client account has been created! Please set your password.',
     'cpt_new_client_email_message_body'  	=> '',
   ];

--- a/common/cpt-client-dashboard.php
+++ b/common/cpt-client-dashboard.php
@@ -205,26 +205,33 @@ function cpt_status_update_request_notification( $message_id ) {
 
   if ( ! $message_id ) { return; }
 
-  $msg_obj        = get_post( $message_id );
-  $sender_id      = $msg_obj->post_author;
-  $client_obj     = get_userdata( get_post_meta( $message_id, 'cpt_clients_user_id', true ) );
-  $profile_url    = cpt_get_client_profile_url( $sender_id );
+  $msg_obj          = get_post( $message_id );
+  $sender_id        = $msg_obj->post_author;
+  $clients_user_id  = get_post_meta( $message_id, 'cpt_clients_user_id', true );
+  $client_data      = cpt_get_client_data( $clients_user_id );
 
-  $from_name      = get_the_author_meta( 'display_name', $msg_obj->post_author );
-  $from_email     = get_the_author_meta( 'user_email', $msg_obj->post_author );
+  $from_name        = get_the_author_meta( 'display_name', $msg_obj->post_author );
+  $from_email       = get_the_author_meta( 'user_email', $msg_obj->post_author );
 
-  $headers[]      = 'Content-Type: text/html; charset=UTF-8';
-  $headers[]      = 'From: ' . $from_name . ' <' . $from_email . '>';
+  $headers[]        = 'Content-Type: text/html; charset=UTF-8';
+  $headers[]        = 'From: ' . $from_name . ' <' . $from_email . '>';
 
-  $to             = get_bloginfo( 'admin_email' );
-  $subject        = $msg_obj->post_title . ' by ' . $from_name;
-  $subject_html   = $msg_obj->post_title . '&nbsp;<br />' . 'by ' . $from_name;
+  $to               = $client_data[ 'manager_email' ];
 
-  $message        = '<p>Please post an update.</p>';
+  if ( get_option( 'cpt_status_update_req_notice_email' ) ) {
+    $cc             = get_option( 'cpt_status_update_req_notice_email' );
+    $headers[]      = 'Cc: ' . $cc;
+  }
 
-  $button_txt     = 'Go to ' . $from_name;
+  $subject          = $msg_obj->post_title . ' by ' . $from_name;
+  $subject_html     = $msg_obj->post_title . '&nbsp;<br />' . 'by ' . $from_name;
 
-  $message        = cpt_get_email_card( $subject_html, $message, $button_txt, $profile_url );
+  $message          = '<p>Please post an update.</p>';
+
+  $button_txt       = 'Go to ' . $from_name;
+  $profile_url      = cpt_get_client_profile_url( $sender_id );
+
+  $message          = cpt_get_email_card( $subject_html, $message, $button_txt, $profile_url );
 
   wp_mail( $to, $subject, $message, $headers );
 

--- a/common/cpt-client-dashboard.php
+++ b/common/cpt-client-dashboard.php
@@ -30,7 +30,7 @@ function cpt_client_dashboard( $content ) {
 
         ob_start();
 
-          cpt_get_notices( 'cpt_new_message_result' );
+          cpt_get_notices( [ 'cpt_new_message_result' ] );
 
           echo '<p>';
 

--- a/common/cpt-client-dashboard.php
+++ b/common/cpt-client-dashboard.php
@@ -30,9 +30,18 @@ function cpt_client_dashboard( $content ) {
 
         ob_start();
 
-          echo '<p>Welcome back, ' . $client_data[ 'first_name' ] . '!</p>';
-
           cpt_get_notices( 'cpt_new_message_result' );
+
+          echo '<p>';
+
+            echo '<strong>Welcome back, ' . $client_data[ 'first_name' ] . '!</strong>';
+
+            if ( isset( $client_data[ 'manager_id' ] ) ) {
+              echo ' You are working with ' . cpt_get_name( $client_data[ 'manager_id' ] ) . '.';
+            }
+
+          echo '</p>';
+
           cpt_status_update_request_button( $user_id );
 
           /**

--- a/common/cpt-common.css
+++ b/common/cpt-common.css
@@ -40,7 +40,7 @@
     }
 
 .cpt-message.my-message {
-  margin-left: 33.333%;
+  margin-left: 10%;
 }
 
 .client-message .cpt-message-content {
@@ -48,7 +48,7 @@
 }
 
 .cpt-message.not-my-message {
-  margin-right: 33.333%;
+  margin-right: 10%;
 }
 
 .cpt-message.status-update-request {

--- a/common/cpt-common.js
+++ b/common/cpt-common.js
@@ -3,48 +3,58 @@
   // Expanders
   $( document ).ready( function(){
 
+    // When using the expander, every .cpt-click-to-expand should be followed by
+    // a .cpt-expand-this, so that the node list indexes match up.
     let expanderButtons = document.querySelectorAll( '.cpt-click-to-expand' );
-
-    console.log( expanderButtons );
+    let buttonText      = [];
+    let expandableDivs  = document.querySelectorAll( '.cpt-this-expands' );
 
     if ( expanderButtons.length > 0 ) {
 
-      expanderButtons.forEach ( function( button ){
+      for ( let i = 0; i < expanderButtons.length; i++ ) {
 
-        button.addEventListener( 'click', function( e ){
+        buttonText[i] = expanderButtons[i].innerHTML;
+
+        $( expanderButtons[i] ).click( function( event ) {
+
+          event.preventDefault();
+
+          $( expandableDivs[i] ).toggle( 'fast' );
+          $( expandableDivs[i] ).toggleClass( 'open' );
+
+          let formElements = expandableDivs[i].querySelectorAll( 'form input, form select, form textarea' );
+
+          if ( expandableDivs[i].classList.contains( 'open' ) ) {
+
+            expanderButtons[i].innerHTML = 'Cancel';
+
+            formElements.forEach( function( element ){
+
+              if ( element.dataset.required == 'true' ) {
+                element.setAttribute( 'required', '' );
+                element.setAttribute( 'aria-required', 'true' );
+              }
+
+            });
+
+          } else {
+
+            expanderButtons[i].innerHTML = buttonText[i];
+
+            formElements.forEach( function( element ){
+
+              if ( element.dataset.required == 'true' ) {
+                element.removeAttribute( 'required', '' );
+                element.removeAttribute( 'aria-required', 'true' );
+              }
+
+            });
+
+          }
 
         });
 
-        button.nextSibling( '.cpt-expand-this' ){
-
-        }
-
-      });
-
-    }
-
-  });
-
-
-  // Old Expander Function
-  let expandButtonText = $( '.cpt-click-to-expand' ).html();
-
-  $( '.cpt-click-to-expand' ).click( function() {
-
-    let requiredFields = $( this ).next( 'form' )
-
-    $( this ).next( '.cpt-this-expands' ).toggle( 'fast' ).toggleClass( 'cpt-this-is-open' );
-
-    switch ( $( this ).html() ) {
-
-      case expandButtonText:
-        $( this ).html( 'Cancel' );
-        break;
-
-      case 'Cancel':
-      default:
-        $( this ).html( expandButtonText );
-        break;
+      }
 
     }
 

--- a/common/cpt-common.js
+++ b/common/cpt-common.js
@@ -1,11 +1,39 @@
 ( function( $ ) {
 
-  // Expander
+  // Expanders
+  $( document ).ready( function(){
+
+    let expanderButtons = document.querySelectorAll( '.cpt-click-to-expand' );
+
+    console.log( expanderButtons );
+
+    if ( expanderButtons.length > 0 ) {
+
+      expanderButtons.forEach ( function( button ){
+
+        button.addEventListener( 'click', function( e ){
+
+        });
+
+        button.nextSibling( '.cpt-expand-this' ){
+
+        }
+
+      });
+
+    }
+
+  });
+
+
+  // Old Expander Function
   let expandButtonText = $( '.cpt-click-to-expand' ).html();
 
   $( '.cpt-click-to-expand' ).click( function() {
 
-    $( this ).next( '.cpt-this-expands' ).toggle( 'fast' );
+    let requiredFields = $( this ).next( 'form' )
+
+    $( this ).next( '.cpt-this-expands' ).toggle( 'fast' ).toggleClass( 'cpt-this-is-open' );
 
     switch ( $( this ).html() ) {
 

--- a/common/cpt-common.js
+++ b/common/cpt-common.js
@@ -1,9 +1,27 @@
 ( function( $ ) {
 
   // Expander
+  let expandButtonText = $( '.cpt-click-to-expand' ).html();
+
   $( '.cpt-click-to-expand' ).click( function() {
+
     $( this ).next( '.cpt-this-expands' ).toggle( 'fast' );
+
+    switch ( $( this ).html() ) {
+
+      case expandButtonText:
+        $( this ).html( 'Cancel' );
+        break;
+
+      case 'Cancel':
+      default:
+        $( this ).html( expandButtonText );
+        break;
+
+    }
+
   });
+
 
   // Adjust anchor targets.
   $( document ).ready( function(){

--- a/common/cpt-common.js
+++ b/common/cpt-common.js
@@ -22,6 +22,7 @@
           $( expandableDivs[i] ).toggle( 'fast' );
           $( expandableDivs[i] ).toggleClass( 'open' );
 
+          // This adds/removes the *required* attribute based on form visibility.
           let formElements = expandableDivs[i].querySelectorAll( 'form input, form select, form textarea' );
 
           if ( expandableDivs[i].classList.contains( 'open' ) ) {

--- a/common/cpt-common.php
+++ b/common/cpt-common.php
@@ -115,6 +115,7 @@ function cpt_get_client_data( $user_id ) {
     'last_name'   => get_user_meta( $user_id, 'last_name', true ),
     'email'       => $userdata->user_email,
     'client_id'   => get_user_meta( $user_id, 'cpt_client_id', true ),
+    'manager_id'  => get_user_meta( $user_id, 'cpt_client_manager', true ),
     'status'      => get_user_meta( $user_id, 'cpt_client_status', true ),
   ];
 

--- a/common/cpt-common.php
+++ b/common/cpt-common.php
@@ -212,49 +212,51 @@ function cpt_get_email_card( $title = null, $content = null, $button_txt = 'Go',
 * outputs a notice. In the admin, this is a standard WordPress admin notice. On
 * the front end, this is a modal.
 */
-function cpt_get_notices( $transient_key ) {
+function cpt_get_notices( $transient_key_array ) {
 
-  if ( ! $transient_key ) { return; }
+  if ( ! $transient_key_array ) { return; }
 
-  $result = get_transient( $transient_key );
+  foreach ( $transient_key_array as $notice ) {
 
-  if ( ! empty( $result ) ) {
+    $result = get_transient( $notice );
 
-    if ( is_admin() ) {
+    if ( ! empty( $result ) ) {
 
-      if ( is_wp_error( $result ) ) {
-        $wrapper = '<div class="cpt-notice notice notice-error is-dismissible">';
+      if ( is_admin() ) {
+
+        if ( is_wp_error( $result ) ) {
+          $wrapper = '<div class="cpt-notice notice notice-error is-dismissible">';
+        } else {
+          $wrapper = '<div class="cpt-notice notice notice-success is-dismissible">';
+        }
+
       } else {
-        $wrapper = '<div class="cpt-notice notice notice-success is-dismissible">';
+
+        ob_start();
+
+          ?>
+
+            <button class="cpt-notice-dismiss-button">
+              <img src="<?php echo CLIENT_POWER_TOOLS_DIR_URL; ?>frontend/images/cpt-dismiss-button.svg" height="25px" width="25px" />
+            </button>
+
+          <?php
+
+        $dismiss_button = ob_get_clean();
+
+        $wrapper = '<div class="cpt-inline-modal">' . "\n" . $dismiss_button;
+
       }
 
-    } else {
-
-      ob_start();
-
-        ?>
-
-          <button class="cpt-notice-dismiss-button">
-            <img src="<?php echo CLIENT_POWER_TOOLS_DIR_URL; ?>frontend/images/cpt-dismiss-button.svg" height="25px" width="25px" />
-          </button>
-
-        <?php
-
-      $dismiss_button = ob_get_clean();
-
-      $wrapper = '<div class="cpt-inline-modal">' . "\n" . $dismiss_button;
+      echo $wrapper;
+      echo '<p>' . __( $result ) . '</p>';
+      echo '</div>';
 
     }
 
-
-
-    echo $wrapper;
-    echo '<p>' . __( $result ) . '</p>';
-    echo '</div>';
+    delete_transient( $notice );
 
   }
-
-  delete_transient( $transient_key );
 
 }
 

--- a/common/cpt-common.php
+++ b/common/cpt-common.php
@@ -275,6 +275,8 @@ function cpt_login_missing( $redirect_to, $requested_redirect_to, $user ) {
   if ( $redirect_to == cpt_get_client_dashboard_url() ) {
     wp_redirect( cpt_get_client_dashboard_url() . "?cpt_error=login_failed" );
     exit;
+  } else {
+    return $redirect_to;
   }
 
 }

--- a/common/cpt-common.php
+++ b/common/cpt-common.php
@@ -18,7 +18,7 @@ function cpt_add_roles() {
     'Client Manager',
     [
       'cpt-view-clients'    => true,
-      'cpt-manage-clients'  => true,
+      'read',
     ]
   );
 

--- a/common/cpt-common.php
+++ b/common/cpt-common.php
@@ -58,8 +58,9 @@ function cpt_is_client( $user_id = null ) {
 }
 
 
-function cpt_get_client_profile_url( $user_id ) {
-  return add_query_arg( 'user_id', $user_id, admin_url( 'admin.php?page=cpt' ) );
+function cpt_get_client_profile_url( $clients_user_id ) {
+  if ( ! $clients_user_id ) { return; }
+  return add_query_arg( 'user_id', $clients_user_id, admin_url( 'admin.php?page=cpt' ) );
 }
 
 
@@ -85,44 +86,45 @@ function cpt_is_client_dashboard() {
 }
 
 
-function cpt_get_client_name( $user_id ) {
+function cpt_get_name( $user_id ) {
 
   if ( ! $user_id ) { return; }
 
   $user_meta = get_userdata( $user_id );
 
   if ( $user_meta->first_name && $user_meta->last_name ) {
-    $client_name = $user_meta->first_name . ' ' . $user_meta->last_name;
+    $name = $user_meta->first_name . ' ' . $user_meta->last_name;
   } else {
-    $client_name = $user_meta->display_name;
+    $name = $user_meta->display_name;
   }
 
-  return $client_name;
+  return $name;
 
 }
 
 
 // Returns an array with the user's details.
-function cpt_get_client_data( $user_id ) {
+function cpt_get_client_data( $clients_user_id ) {
 
-  if ( ! $user_id ) { return; }
+  if ( ! $clients_user_id ) { return; }
 
-  $userdata = get_userdata( $user_id );
+  $userdata = get_userdata( $clients_user_id );
 
   $client_data = [
-    'user_id'       => $user_id,
-    'first_name'    => get_user_meta( $user_id, 'first_name', true ),
-    'last_name'     => get_user_meta( $user_id, 'last_name', true ),
+    'user_id'       => $clients_user_id,
+    'first_name'    => get_user_meta( $clients_user_id, 'first_name', true ),
+    'last_name'     => get_user_meta( $clients_user_id, 'last_name', true ),
     'email'         => $userdata->user_email,
-    'client_id'     => get_user_meta( $user_id, 'cpt_client_id', true ),
-    'manager_id'    => cpt_get_client_manager_id( $user_id ),
-    'manager_email' => cpt_get_client_manager_email( $user_id ),
-    'status'        => get_user_meta( $user_id, 'cpt_client_status', true ),
+    'client_id'     => get_user_meta( $clients_user_id, 'cpt_client_id', true ),
+    'manager_id'    => cpt_get_client_manager_id( $clients_user_id ),
+    'manager_email' => cpt_get_client_manager_email( $clients_user_id ),
+    'status'        => get_user_meta( $clients_user_id, 'cpt_client_status', true ),
   ];
 
   return $client_data;
 
 }
+
 
 function cpt_get_client_manager_id( $clients_user_id ) {
 
@@ -148,6 +150,7 @@ function cpt_get_client_manager_id( $clients_user_id ) {
   return $manager_id;
 
 }
+
 
 function cpt_get_client_manager_email( $clients_user_id ) {
 

--- a/common/cpt-common.php
+++ b/common/cpt-common.php
@@ -90,12 +90,12 @@ function cpt_get_name( $user_id ) {
 
   if ( ! $user_id ) { return; }
 
-  $user_meta = get_userdata( $user_id );
+  $userdata = get_userdata( $user_id );
 
-  if ( $user_meta->first_name && $user_meta->last_name ) {
-    $name = $user_meta->first_name . ' ' . $user_meta->last_name;
+  if ( isset( $userdata->first_name ) && isset( $userdata->last_name ) ) {
+    $name = $userdata->first_name . ' ' . $userdata->last_name;
   } else {
-    $name = $user_meta->display_name;
+    $name = $userdata->display_name;
   }
 
   return $name;
@@ -132,9 +132,9 @@ function cpt_get_client_manager_id( $clients_user_id ) {
 
   $userdata = get_userdata( get_user_meta( $clients_user_id, 'cpt_client_manager', true ) );
 
-  if ( $userdata && isset( $userdata->user_email ) ) {
+  if ( $userdata && isset( $userdata->ID ) ) {
 
-    $manager_id = $userdata->user_email;
+    $manager_id = $userdata->ID;
 
   } else if ( get_option( 'cpt_default_client_manager' ) ) {
 

--- a/common/cpt-common.php
+++ b/common/cpt-common.php
@@ -110,16 +110,67 @@ function cpt_get_client_data( $user_id ) {
   $userdata = get_userdata( $user_id );
 
   $client_data = [
-    'user_id'     => $user_id,
-    'first_name'  => get_user_meta( $user_id, 'first_name', true ),
-    'last_name'   => get_user_meta( $user_id, 'last_name', true ),
-    'email'       => $userdata->user_email,
-    'client_id'   => get_user_meta( $user_id, 'cpt_client_id', true ),
-    'manager_id'  => get_user_meta( $user_id, 'cpt_client_manager', true ),
-    'status'      => get_user_meta( $user_id, 'cpt_client_status', true ),
+    'user_id'       => $user_id,
+    'first_name'    => get_user_meta( $user_id, 'first_name', true ),
+    'last_name'     => get_user_meta( $user_id, 'last_name', true ),
+    'email'         => $userdata->user_email,
+    'client_id'     => get_user_meta( $user_id, 'cpt_client_id', true ),
+    'manager_id'    => cpt_get_client_manager_id( $user_id ),
+    'manager_email' => cpt_get_client_manager_email( $user_id ),
+    'status'        => get_user_meta( $user_id, 'cpt_client_status', true ),
   ];
 
   return $client_data;
+
+}
+
+function cpt_get_client_manager_id( $clients_user_id ) {
+
+  if ( ! $clients_user_id ) { return; }
+
+  $userdata = get_userdata( get_user_meta( $clients_user_id, 'cpt_client_manager', true ) );
+
+  if ( $userdata && isset( $userdata->user_email ) ) {
+
+    $manager_id = $userdata->user_email;
+
+  } else if ( get_option( 'cpt_default_client_manager' ) ) {
+
+    $manager_id = get_option( 'cpt_default_client_manager' );
+
+  } else {
+
+    $userdata   = get_user_by_email( get_bloginfo( 'admin_email' ) );
+    $manager_id = $userdata->ID;
+
+  }
+
+  return $manager_id;
+
+}
+
+function cpt_get_client_manager_email( $clients_user_id ) {
+
+  if ( ! $clients_user_id ) { return; }
+
+  $userdata = get_userdata( get_user_meta( $clients_user_id, 'cpt_client_manager', true ) );
+
+  if ( $userdata && isset( $userdata->user_email ) ) {
+
+    $manager_email = $userdata->user_email;
+
+  } else if ( get_option( 'cpt_default_client_manager' ) ) {
+
+    $userdata       = get_userdata( get_option( 'cpt_default_client_manager' ) );
+    $manager_email  = $userdata->user_email;
+
+  } else {
+
+    $manager_email = get_bloginfo( 'admin_email' );
+
+  }
+
+  return $manager_email;
 
 }
 

--- a/common/cpt-messages.php
+++ b/common/cpt-messages.php
@@ -347,7 +347,7 @@ function cpt_message_notification( $message_id ) {
   $msg_obj          = get_post( $message_id );
   $sender_id        = $msg_obj->post_author;
   $clients_user_id  = get_post_meta( $message_id, 'cpt_clients_user_id', true );
-  $client_obj       = get_userdata( $clients_user_id );
+  $client_data      = cpt_get_client_data( $clients_user_id );
 
   $from_name        = get_the_author_meta( 'display_name', $msg_obj->post_author );
   $from_email       = get_the_author_meta( 'user_email', $msg_obj->post_author );
@@ -355,7 +355,6 @@ function cpt_message_notification( $message_id ) {
   $headers[]        = 'Content-Type: text/html; charset=UTF-8';
   $headers[]        = 'From: ' . $from_name . ' <' . $from_email . '>';
 
-  $to               = $client_obj->user_email;
   $subject          = $msg_obj->post_title ? $msg_obj->post_title : __( 'You have a new message from' ) . ' ' . $from_name;
 
   if ( $send_this_msg_content ) {
@@ -366,10 +365,14 @@ function cpt_message_notification( $message_id ) {
 
     if ( $sender_id == $clients_user_id ) {
 
+      $to           = $client_data[ 'manager_email' ];
+
       $message      = '<p>' . __( 'To read your message, please visit your client dashboard.' ) . '</p>';
       $button_url   = cpt_get_client_profile_url( $clients_user_id ) . '#cpt-message-' . $message_id;
 
     } else {
+
+      $to           = $client_data[ 'email' ];
 
       $message      = '<p>' . __( 'To read this message, please view the client page.' ) . '</p>';
       $button_url   = cpt_get_client_dashboard_url() . '#cpt-message-' . $message_id;

--- a/frontend/cpt-frontend.php
+++ b/frontend/cpt-frontend.php
@@ -227,7 +227,7 @@ function cpt_password_reset_message( $message, $key, $user_login, $user_data ) {
 
   if ( Common\cpt_is_client( $user_data->ID ) ) {
 
-    $site_name  = get_option( 'cpt_new_client_email_from_name' );
+    $site_name  = get_bloginfo( 'name' );
     $url        = Common\cpt_get_client_dashboard_url() . '?cpt_login=setpw&key=' . $key . '&login=' . urlencode( $user_login );
 
     $message  = __( 'Someone has requested a password reset for the following account:' ) . "\r\n\r\n";

--- a/frontend/cpt-frontend.php
+++ b/frontend/cpt-frontend.php
@@ -27,7 +27,7 @@ add_filter( 'body_class', function( $classes ) {
 *
 * If 3 or 4 are called for, either cpt_login=setpw in the URL for 3 or because
 * the user is logged in and clicks a login/logout link for 4, then they are
-* shown instead of the 1/2 modal.
+* shown the password change form instead of the 1/2 modal.
 */
 function cpt_login() {
 
@@ -361,9 +361,18 @@ function cpt_process_password_change() {
 
       }
 
-      // Resets the password and sends back the password_changed success code.
+      // Resets the password.
       reset_password( $user, $pass1 );
-      wp_redirect( add_query_arg( 'cpt_success', 'password_changed', $dashboard ) );
+
+      // Determines the $redirect destination based on the user's role.
+      if ( in_array( 'cpt-client-manager', $user->roles ) ) {
+        $redirect_url = admin_url( 'admin.php?page=cpt' );
+      } else {
+        $redirect_url = $dashboard;
+      }
+
+      // Redirect the user with the password_changed success code.
+      wp_redirect( add_query_arg( 'cpt_success', 'password_changed', $redirect_url ) );
       exit;
 
     } else {

--- a/readme.txt
+++ b/readme.txt
@@ -51,7 +51,7 @@ Client Power Tools is built to be customizable where you need it to be. Here are
 * **New-client email.** You can customize the email sent to newly added clients so that it reflects the name, email address, subject line, and messaging you prefer.
 * **Client IDs.** When adding or updating a client, you can add a custom client ID.
 * **Client statuses.** You can customize the default statuses (potential, active, inactive).
-* **Status update request frequency.** Change how often the status update request button is available to your clients.
+* **Status update request frequency.** Change how often the status update request button is available to your clients, or turn it off.
 * **Status update request recipient.** Designate one person to field all the status update requests.
 * **Design.** The front-end design of Client Power Tools is as minimal as possible so that Client Power Tools blends into your existing theme. But you can override the Client Power Tools styles as long as you know a little CSS. (See the [documentation](https://clientpowertools.com/documentation/) for more details.)
 

--- a/readme.txt
+++ b/readme.txt
@@ -9,7 +9,7 @@ Stable tag: trunk
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.en.html
 
-A free, easy-to-use private client dashboard and communication portal built for independent contractors, consultants, lawyers, and other professionals.
+A free, easy-to-use client dashboard and communication portal built for independent contractors, consultants, lawyers, and other professionals.
 
 
 == Description ==

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 Contributors: samglover
 Tags: access control,clients,communication,portal,restrict access,restrict pages
 Requires at least: 5.5
-Tested up to: 5.5.1
+Tested up to: 5.5.3
 Requires PHP: 7.3.5
 Stable tag: trunk
 License: GPLv3
@@ -51,8 +51,9 @@ Client Power Tools is built to be customizable where you need it to be. Here are
 * **New-client email.** You can customize the email sent to newly added clients so that it reflects the name, email address, subject line, and messaging you prefer.
 * **Client IDs.** When adding or updating a client, you can add a custom client ID.
 * **Client statuses.** You can customize the default statuses (potential, active, inactive).
+* **Client managers.** You can assign a client manager to each client.
 * **Status update request frequency.** Change how often the status update request button is available to your clients, or turn it off.
-* **Status update request recipient.** Designate one person to field all the status update requests.
+* **Status update request recipient.** Designate one person to get notified of all status update requests.
 * **Design.** The front-end design of Client Power Tools is as minimal as possible so that Client Power Tools blends into your existing theme. But you can override the Client Power Tools styles as long as you know a little CSS. (See the [documentation](https://clientpowertools.com/documentation/) for more details.)
 
 
@@ -61,14 +62,34 @@ Client Power Tools is built to be customizable where you need it to be. Here are
 
 == Upgrade Notice ==
 
-This release adds several user-requested features. In settings, now you can disable the status request button entirely. You can also change the default email notification behavior to include the full message, rather than just a notification, but you can override this default on individual messages.
+This release adds client managers. You can manage client managers from the new **Managers** submenu, managers appear next to their clients in the client list, and clients appear with their manager in the manager list.
 
-Finally, when you try to add a new client when there is already a WordPress user account with the same email address, the user is simply given the Client role rather than returning an error. (The documentation will be updated, as well.)
+Messages and status update requests now go to the client manager. (The email will be CC'd to the now-optional status update request notification email address, if you have set one.) New client emails will now come from the client manager instead of a default name and email address.
 
-There's also a bunch of smaller tweaks and improvements.
+The add-client form has been moved to the Clients page.
+
+There's also the usual tweaks and improvements.
 
 
 == Changelog ==
+
+### 1.3
+
+#### Added
+- Client managers can now be added and removed from the new **Managers** submenu, and are also shown in the client list and client profile. As you can when adding a client, you can add a new or existing WordPress user.
+- Assign a default client manager in the settings.
+- Filter the client list by clients assigned to you ("Mine").
+
+#### Changed
+- The add-client form is now on the Clients page.
+- Messages and status update requests now go to the client manager. (The email will be CC'd to the now-optional status update request notification email address, if you have set one.)
+- New client emails will now come from the client manager instead of a default name and email address.
+- Update the element expander script so it can handle multiple expanders on the same page. Also, form elements within an expander with data-required="true" will have the required attributes removed when hidden.
+- Make cpt_get_notices() easier to use by changing the argument to an array so it only needs to be called once.
+
+#### Fixed
+- The standard login form no longer redirects to a blank page when a redirect is present.
+
 
 ### 1.2.1 - 2020-10-24
 
@@ -76,7 +97,7 @@ There's also a bunch of smaller tweaks and improvements.
 - Adding an existing user as a client now works as it should.
 
 
-### 1.2.0 - 2020-10-23
+### 1.2 - 2020-10-23
 
 #### Added
 - Setting to disable the status request button entirely.
@@ -87,7 +108,7 @@ There's also a bunch of smaller tweaks and improvements.
 - Creating a new client with an existing user's email address now adds the Client role to the existing user instead of returning an error.
 
 
-### 1.1.0 - 2020-10-20
+### 1.1 - 2020-10-20
 
 #### Added
 - Delete a client from the client's profile page, under **Edit Client**.


### PR DESCRIPTION
### 1.3

#### Added
- Client managers can now be added and removed from the new **Managers** submenu, and are also shown in the client list and client profile. As you can when adding a client, you can add a new or existing WordPress user.
- Assign a default client manager in the settings.
- Filter the client list by clients assigned to you ("Mine").

#### Changed
- The add-client form is now on the Clients page.
- Messages and status update requests now go to the client manager. (The email will be CC'd to the now-optional status update request notification email address, if you have set one.)
- New client emails will now come from the client manager instead of a default name and email address.
- Update the element expander script so it can handle multiple expanders on the same page. Also, form elements within an expander with data-required="true" will have the required attributes removed when hidden.
- Make cpt_get_notices() easier to use by changing the argument to an array so it only needs to be called once.

#### Fixed
- The standard login form no longer redirects to a blank page when a redirect is present.